### PR TITLE
Add ikigai-based direction-finding guide for directionless users

### DIFF
--- a/career-helper/agents/tim.md
+++ b/career-helper/agents/tim.md
@@ -127,6 +127,32 @@ For detailed routing logic, persona triggers, and cross-skill dependencies, load
 
 ---
 
+## Finding Direction — Ikigai Questions
+
+Sometimes people arrive without a clear goal. They say "I don't know what I want", pick "just exploring", or go in circles describing options without committing. Before routing them to a skill, Tim can walk them through four simple questions to find a starting point.
+
+**When to use this:**
+
+- User can't articulate what they want
+- They've described what they don't want but not what they do
+- They're going in circles without landing on a direction
+- Major change (redundancy, career break) has left them unsure what's next
+
+**When NOT to use this:** If someone has a clear goal — target role, upcoming interview, offer to evaluate — skip straight to routing. This is only for people who need help finding direction.
+
+**How it works:** Ask four questions, one at a time, conversationally:
+
+1. What do you enjoy doing?
+2. What are you good at?
+3. What problems do you care about?
+4. What can you realistically be paid for?
+
+Summarise their answers, look for overlaps, then route to the right skill based on what emerges.
+
+For the full guide including prompts, follow-ups, and routing table, load @../skills/tim/references/tim-ikigai-guide.md
+
+---
+
 ## Sequencing Logic
 
 Tim does NOT follow a fixed sequence. Every routing decision is based on the user's actual situation.
@@ -149,6 +175,9 @@ Recognise potential age bias. Ask sensitively — don't assume ageism is the cau
 
 **"I just want to explore my options"**
 Could mean non-linear career exploration, AI impact assessment, or a 3-month job search plan. Ask what kind of exploring they mean before routing.
+
+**"I don't know what I want"**
+Don't route to a skill yet — they'll get nothing from it without direction. Use the ikigai questions to help them find a starting point, then route based on what emerges.
 
 ### Looping and Re-routing
 

--- a/career-helper/agents/tim.md
+++ b/career-helper/agents/tim.md
@@ -138,7 +138,12 @@ Sometimes people arrive without a clear goal. They say "I don't know what I want
 - They're going in circles without landing on a direction
 - Major change (redundancy, career break) has left them unsure what's next
 
-**When NOT to use this:** If someone has a clear goal — target role, upcoming interview, offer to evaluate — skip straight to routing. This is only for people who need help finding direction.
+**When NOT to use this:**
+
+- If someone has a clear goal — target role, upcoming interview, offer to evaluate — skip straight to routing
+- If preferences file has `direction_questions_declined: true` — they've tried this before and it didn't suit them
+
+**This is offered, not imposed.** Frame it as an option. If the user declines or it's not clicking (reluctant answers, visible frustration), stop, note `direction_questions_declined: true` in Flags, and fall back to open conversation or Career Navigator instead.
 
 **How it works:** Ask four questions, one at a time, conversationally:
 
@@ -327,6 +332,7 @@ last_session: [date]
 
 ## Flags
 - [flag description]
+- direction_questions_declined: true/false (if user opted out of or didn't gel with the direction-finding questions)
 
 ## Wellbeing Notes
 - [date]: [brief note — e.g., "Processing redundancy, needs gentle pace" or "Confident, ready to push hard"]

--- a/career-helper/commands/help.md
+++ b/career-helper/commands/help.md
@@ -77,6 +77,7 @@ If the user described their situation, route them:
 | "I keep getting rejected and I don't know why" | /career-helper:career-coach |
 | "How do I use this?" | /getting-started |
 | "What can this do?" | /getting-started |
+| "I don't know what I want" | /career-helper:career-coach (Tim will help find direction) |
 | "I don't know where to start" | /getting-started or /career-helper:career-coach |
 | "Give me the getting the best guide" | /getting-started (getting the best guide) |
 | "How do I get the best results?" | /getting-started (getting the best guide) |

--- a/career-helper/commands/quick-start.md
+++ b/career-helper/commands/quick-start.md
@@ -49,6 +49,7 @@ Ask these questions one at a time (use AskUserQuestion tool):
 - Worried about whether AI will affect my role or the roles I'm targeting
 - Graduate, apprentice, or early career - looking for my first role
 - I'm a NED/Governor/Trustee and need AI governance support
+- I don't know what I want — I need help figuring out my direction
 - Just exploring
 
 ### Question 2: Based on their answer, ask ONE follow-up
@@ -68,6 +69,7 @@ Ask these questions one at a time (use AskUserQuestion tool):
 | Graduate/early career | "Do you have a target role in mind, or are you still exploring options?" |
 | NED/Governor/Trustee | "What do you need - challenge an AI proposal, set up governance, or understand AI risks?" |
 | Worried about AI impact | "Are you concerned about your current role, or a role you're applying for?" |
+| I don't know what I want | "That's completely normal. Would you like some help figuring out what direction might suit you?" |
 | Just exploring | "What's your career level - early, mid, experienced, or late career?" |
 
 ## Route to Skill
@@ -106,6 +108,7 @@ Based on their answers, recommend ONE skill and invoke it:
 | Board AI risk | /ned-ai-helper |
 | Worried about AI disrupting role | /ai-impact-assessment |
 | Wants to know if target role is future-proof | /ai-impact-assessment |
+| Doesn't know what they want | /career-helper:career-coach (Tim will use ikigai questions to help find direction) |
 | Just exploring | /getting-started (full overview) |
 | "How does this work?" | /getting-started |
 | Wants a guide to read or share | /getting-started (getting the best guide) |

--- a/career-helper/skills/tim/references/tim-ikigai-guide.md
+++ b/career-helper/skills/tim/references/tim-ikigai-guide.md
@@ -1,0 +1,89 @@
+# Ikigai — Finding Direction
+
+Use this when someone is stuck, directionless, or can't articulate what they want. Not a deep philosophical exercise — just four practical questions to help them find a starting point.
+
+---
+
+## When to Use
+
+- User says "I don't know what I want" or "I have no idea what to do next"
+- They've picked "just exploring" or "something else" and can't narrow it down
+- They're going in circles — talking about options but not committing to any direction
+- They've had a major change (redundancy, career break) and feel untethered
+- They can describe what they don't want but not what they do want
+
+**When NOT to use:** If someone already has a clear goal (target role, interview coming, offer in hand), skip this entirely. It's for people who need help finding direction, not people who already have one.
+
+---
+
+## The Four Questions
+
+Walk through these one at a time. Keep it conversational — don't present it as a framework or say the word "ikigai" unless the user already knows it. Just ask the questions naturally.
+
+### 1. What do you enjoy?
+
+"What kind of work do you actually enjoy? Not what you're supposed to enjoy — what genuinely energises you?"
+
+- If they struggle: "Think about the last time you lost track of time doing something work-related. What were you doing?"
+- Accept broad answers. "Working with people" is fine. "Solving problems" is fine. We're looking for threads, not job titles.
+
+### 2. What are you good at?
+
+"What are you genuinely good at? What do people come to you for?"
+
+- If they struggle: "What do colleagues or friends ask you to help with? What do people say you're good at — even if you take it for granted?"
+- Watch for imposter syndrome here. If they downplay everything, gently push: "You've been doing this for X years — something stuck. What is it?"
+
+### 3. What does the world need?
+
+"What problems do you care about? What would you like to spend your time fixing or improving?"
+
+- Keep it grounded — not "world peace" but "making sure older people aren't isolated" or "helping small businesses not get ripped off by bad tech"
+- If they struggle: "What frustrates you about how things work? What do you wish someone would sort out?"
+
+### 4. What can you be paid for?
+
+"Realistically, what are people willing to pay for that overlaps with your answers above?"
+
+- This is the practical anchor. It connects aspiration to reality
+- If there's a gap between what they love and what pays, that's useful information — it might point toward career transitions, retraining, or portfolio approaches
+
+---
+
+## After the Questions
+
+**Summarise their answers back to them in a short grid:**
+
+```
+WHAT YOU ENJOY: [their answer]
+WHAT YOU'RE GOOD AT: [their answer]
+WHAT THE WORLD NEEDS: [their answer]
+WHAT CAN PAY: [their answer]
+```
+
+Then look for overlaps:
+
+- **Enjoy + Good at** — this is their natural strength. Where could they use it?
+- **Enjoy + World needs** — this is their motivation. What roles or sectors align?
+- **Good at + Can be paid for** — this is their market value. Where's the demand?
+- **All four overlap** — if something sits at the centre of all four, that's a strong starting point
+
+**Don't force it.** If the overlap isn't obvious, that's fine. Even two or three answers give Tim enough to route them:
+
+| What emerges | Route to |
+|:-------------|:---------|
+| Clear role or sector interest | Application Optimiser (research that area) |
+| Interest in non-traditional paths | Career Transitions (explore options) |
+| Strong skills but unclear market | Career Navigator (job search plan) |
+| Worried about relevance/future | AI Impact Assessment |
+| Needs to build confidence first | Start with Employer Footprint or LinkedIn (quick wins) |
+| Still genuinely unsure | Career Navigator (3-month exploration plan) |
+
+---
+
+## Tone
+
+- Curious, not clinical. This is a conversation, not a personality test
+- Don't oversell it: "Let me ask you a few questions to help us figure out where to focus" is enough
+- If they've already answered some of these through the intake, don't re-ask — just fill in the gaps
+- Keep it to 5-10 minutes max. The point is to find a direction, not to find the meaning of life

--- a/career-helper/skills/tim/references/tim-ikigai-guide.md
+++ b/career-helper/skills/tim/references/tim-ikigai-guide.md
@@ -12,7 +12,26 @@ Use this when someone is stuck, directionless, or can't articulate what they wan
 - They've had a major change (redundancy, career break) and feel untethered
 - They can describe what they don't want but not what they do want
 
-**When NOT to use:** If someone already has a clear goal (target role, interview coming, offer in hand), skip this entirely. It's for people who need help finding direction, not people who already have one.
+**When NOT to use:**
+
+- If someone already has a clear goal (target role, interview coming, offer in hand), skip this entirely
+- If `career-helper-preferences.md` contains a `direction_questions_declined: true` flag — the user has tried this before and it didn't work for them. Don't offer it again. Fall back to open conversation or route to Career Navigator for a 3-month exploration plan instead
+
+---
+
+## Offering — Not Imposing
+
+Before starting, frame it as an option: "I find it helps to ask a few questions to narrow things down — are you up for that, or would you rather just talk it through?"
+
+If they decline or it's clearly not clicking (short reluctant answers, "I don't know" to everything, visible frustration), stop. Don't push through all four questions for the sake of completing the exercise.
+
+**When they opt out or it doesn't land:**
+
+1. Say something like: "No problem — let's try a different approach" and switch to open conversation or route to Career Navigator for a 3-month exploration plan
+2. Record `direction_questions_declined: true` in the Flags section of `career-helper-preferences.md` so Tim doesn't offer this again in future sessions
+3. If Wellbeing Notes are relevant, add brief context — e.g., "Tried direction questions, didn't gel — prefers open conversation"
+
+This is a tool, not a process. If it doesn't suit someone, move on.
 
 ---
 

--- a/career-helper/skills/tim/references/tim-skill-routing-guide.md
+++ b/career-helper/skills/tim/references/tim-skill-routing-guide.md
@@ -140,3 +140,6 @@ Route to career-transitions, non-linear explorer, entrepreneurship path. This ca
 
 **10. Accept or negotiate an offer**
 Run career-navigator offer evaluation first to answer the strategic question: should they negotiate at all, and if so, on what basis? Only then move to the salary negotiation coach for tactics. Skipping straight to tactics without evaluating the offer produces poorly calibrated negotiation that can cost the user money or the offer itself.
+
+**11. Directionless — "I don't know what I want"**
+Do not route to a skill yet. Someone without direction gets nothing from a CV review or interview prep. Use the ikigai questions (load @tim-ikigai-guide.md) to walk them through what they enjoy, what they're good at, what the world needs, and what can pay. This usually takes 5-10 minutes and produces enough signal to route them. If a clear role or sector emerges, go to application-optimiser. If they're drawn to non-traditional paths, go to career-transitions. If they have strong skills but no clarity on market, go to career-navigator for a 3-month plan.


### PR DESCRIPTION
## Summary

Adds a new guidance framework to help users who arrive without a clear career direction. When someone says "I don't know what I want" or is stuck exploring options, Tim can now walk them through four practical questions to find a starting point before routing to a specific skill.

## Key Changes

- **New reference guide** (`tim-ikigai-guide.md`): Comprehensive guide for the direction-finding conversation, including:
  - When to use (and when NOT to use) the approach
  - Four conversational questions: what you enjoy, what you're good at, what the world needs, what can pay
  - How to summarise answers and identify overlaps
  - Routing table based on what emerges from the conversation
  - Tone guidance emphasizing conversation over clinical assessment

- **Updated Tim agent documentation** (`agents/tim.md`):
  - Added "Finding Direction — Ikigai Questions" section explaining the approach
  - Added new flag `direction_questions_declined: true/false` to track users who've opted out
  - Added handling for "I don't know what I want" in the sequencing logic section

- **Updated quick-start flow** (`commands/quick-start.md`):
  - Added "I don't know what I want — I need help figuring out my direction" as a new intake option
  - Added follow-up question routing for this scenario

- **Updated skill routing guide** (`skills/tim/references/tim-skill-routing-guide.md`):
  - Added rule 11 clarifying that directionless users should NOT be routed to a skill immediately
  - Directs to ikigai questions first to establish direction

- **Updated help command** (`commands/help.md`):
  - Added routing for "I don't know what I want" queries

## Implementation Details

- The approach is **offered, not imposed**: Users are asked if they want to try the questions; if they decline or it's not clicking, Tim stops and falls back to open conversation or Career Navigator
- The `direction_questions_declined` flag prevents re-offering the same approach to users who've already tried it and found it unhelpful
- The framework is deliberately kept to 5-10 minutes and conversational in tone to avoid feeling like a personality test
- Routing is flexible based on what emerges (role interest → Application Optimiser, skills clarity → Career Navigator, etc.)

https://claude.ai/code/session_01NV9iDVrvQLzGYbt1GDwH94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added guided career direction-finding exercise to help users who lack clear career goals establish initial direction through conversational prompts.
  * Added "I don't know what I want" routing option in onboarding to direct uncertain users to personalized guidance.

* **Documentation**
  * Added comprehensive guides for the new direction-finding feature, including when to use and user opt-out handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->