### PR TITLE
docs: clarify non-commercial use and commercial licensing in LICENSE (v1.10.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "career-helper",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "End-to-end career support for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Now includes non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling",
   "owner": {
     "name": "Prosper AI Consulting"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.10.4] - 2026-04-15
+
+### Added
+- **Non-commercial use clarification** added to `LICENSE`. CC BY-NC 4.0 already permitted non-profit, public sector, charitable, and personal use, but a community question from an unemployed job seeker asking whether they could build a local-model interface (Ollama, Llama, or Qwen) around Career Helper and offer it to a national public employment service made it clear that the licence text was not explicit enough. The new section leads with the spirit of the licence (open reuse, sharing, commenting, and paying it forwards with warmth and kindness, as long as the work is not used for commercial gain), then unpacks five welcomed use cases (personal use including local-model wrappers, public employment services, charities and community groups, schools and universities, and mutual aid or volunteer coaches) and four uses that still require a commercial arrangement (paid recruitment and outplacement, paid external consultancies even when the paying party is a public body, commercial repackaging, and commercial model training).
+- **Commercial licensing route** in `LICENSE`. Commercial users are asked to open a GitHub issue or discussion rather than walk away. Proceeds from any commercial licensing arrangement will be donated to an appropriate charity supporting job seekers and people facing barriers to employment.
+- **"Forks and derivatives" guidance** in `LICENSE` covering licence retention, upstream attribution, telling end users the upstream project exists, and contributing improvements back.
+
+### Changed
+- Plugin and marketplace version bumped to 1.10.4
+
+---
+
 ## [1.10.3] - 2026-04-13
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -76,6 +76,101 @@ automatically included and should be retained.
 
 =======================================================================
 
+NON-COMMERCIAL USE CLARIFICATION:
+
+The spirit of this licence is simple: open reuse, sharing, commenting, and
+paying it forwards with warmth and kindness, as long as the work is not
+used for commercial gain. Everything below is a practical unpacking of
+that one sentence. If there is ever a conflict between the spirit above
+and the detail below, the spirit wins.
+
+CC BY-NC 4.0 prohibits commercial use, but it does permit a wide range of
+non-profit, public sector, charitable, and personal uses. This clarification
+makes the intent of the licensor explicit, prompted by a community question
+about whether an unemployed job seeker could build a local-model interface
+(for example, a simple web UI wrapping Ollama, Llama, or Qwen) around
+Career Helper and offer it to a public employment service. The short answer
+to that question is yes, with warmth and with thanks for asking.
+
+The following uses are expressly welcomed, provided attribution and the
+spirit of "Pay It Forward" below are preserved.
+
+  1. Personal use by an individual job seeker, including cloning, forking,
+     self-hosting, and wrapping the skills in a local interface (for
+     example, a web UI on top of Ollama, Llama, Qwen, or any other local
+     model) to help that person, their family, or their friends find work.
+
+  2. Use by public sector bodies, government employment services, state
+     welfare agencies, and equivalent public bodies in any country, to
+     help the job seekers they serve, provided no fee is charged to the
+     job seeker.
+
+  3. Use by registered charities, non-profits, and community groups that
+     support people into work, retraining, or career change, provided the
+     service is free at the point of use.
+
+  4. Use by schools, colleges, and universities in free careers services,
+     alumni support, and employability programmes.
+
+  5. Use by mutual aid groups, volunteer career coaches, and individuals
+     running free workshops or study groups for job seekers.
+
+The following uses are NOT permitted without separate written permission
+from the licensor.
+
+  1. Use by commercial recruitment agencies, outplacement firms, executive
+     search firms, or career coaches who charge fees to clients.
+
+  2. Use by external consultancies that are paid to deliver career
+     services built on Career Helper, including cases where the paying
+     party is itself a public body. In plain terms: a public employment
+     service using Career Helper internally to help its own claimants is
+     welcome; a commercial consultancy paid by that same public body to
+     run a Career Helper service on its behalf is not.
+
+  3. Repackaging, rebranding, or selling Career Helper, or any substantial
+     derivative, as part of a commercial product, subscription, or
+     service.
+
+  4. Training proprietary AI models for commercial deployment on Career
+     Helper content.
+
+COMMERCIAL LICENSING:
+
+  If your intended use is commercial, please get in touch rather than
+  walking away. Open an issue or a discussion on the GitHub repository
+  describing what you would like to do, and we will have a conversation
+  about a commercial licence. Any proceeds from commercial licensing
+  arrangements will be donated to an appropriate charity, chosen with
+  the spirit of this project in mind: supporting job seekers, people
+  out of work, and those facing barriers to employment. We would rather
+  say yes on sensible terms and turn the proceeds into more help for
+  more people than have anyone feel shut out of using Career Helper.
+
+IF YOU ARE UNSURE:
+
+  The guiding question is simple: is money changing hands for the career
+  help itself? If no, and your intent is to help people get into work,
+  you are almost certainly within the spirit of this licence. If yes, you
+  probably need a commercial arrangement. When in doubt, open an issue on
+  the GitHub repository and ask. The licensor has a strong preference for
+  saying yes to non-profit, public sector, and volunteer use.
+
+FORKS AND DERIVATIVES:
+
+  Forks are welcome. If you build a wrapper, a web interface, a
+  local-model adaptation, or any other derivative, please:
+
+    1. Keep the CC BY-NC 4.0 licence on the derivative.
+    2. Acknowledge Career Helper and link back to the upstream repository
+       in your README.
+    3. Tell the people you help that Career Helper exists so they can
+       use it directly themselves.
+    4. Where practical, contribute improvements back upstream so that
+       other job seekers benefit.
+
+=======================================================================
+
 PAY IT FORWARD
 
 This skill is provided as-is, for free, with a pay-it-forward mindset.

--- a/career-helper/.claude-plugin/plugin.json
+++ b/career-helper/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "career-helper",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "End-to-end career support with guided coaching for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Eleven skills including Tim (your personal career coach), getting started guidance, AI impact assessment, employer footprint analysis, social media review, LinkedIn optimisation, ATS CV rewriting, interview preparation, job search strategy, career transitions (including non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling), and board-level AI oversight.",
   "author": {
     "name": "Prosper AI Consulting"


### PR DESCRIPTION
## Summary

Prompted by a community question from an unemployed job seeker asking whether they could build a local-model interface (Ollama, Llama, or Qwen) around Career Helper and offer it to a public employment service. CC BY-NC 4.0 already permitted this, but the intent was not obvious enough to a non-lawyer reading the licence for the first time. This PR makes the intent explicit.

## Changes

- **`LICENSE`**: new "Non-commercial use clarification" section that leads with the spirit of the licence (open reuse, sharing, commenting, and paying it forwards with warmth and kindness, as long as the work is not used for commercial gain) and then unpacks it.
  - Five expressly welcomed use cases: personal use including local-model wrappers, public employment services and state welfare agencies, charities and community groups, schools and universities, and mutual aid or volunteer coaches. No named public bodies; the category is kept generic.
  - Four uses that still need a commercial arrangement: paid recruitment and outplacement, paid external consultancies (including when the paying party is itself a public body), commercial repackaging, and commercial model training.
  - New "Commercial licensing" block asking commercial users to open an issue or discussion rather than walk away, and noting that any commercial licensing proceeds will be donated to an appropriate charity supporting job seekers and people facing barriers to employment.
  - New "Forks and derivatives" block covering licence retention, upstream attribution, telling end users the upstream project exists, and contributing improvements back.
- **`CHANGELOG.md`**: new 1.10.4 entry dated 2026-04-15.
- **`career-helper/.claude-plugin/plugin.json`** and **`.claude-plugin/marketplace.json`**: patch version bump 1.10.3 to 1.10.4.

## House style

- No em dashes in any of the new content.
- UK English throughout (`licence` as noun, `non-profit`, `programmes`, `organise`).
- Oxford comma used in all lists of three or more.
- No emojis; plain text labels only.

## Test plan

- [ ] Read the full LICENSE top-to-bottom to confirm the clarification flows naturally between "Attribution requirements" and "Pay it forward", and that the spirit-first framing reads warmly.
- [ ] Confirm `plugin.json` and `marketplace.json` versions match at 1.10.4.
- [ ] Confirm the CHANGELOG entry is dated 2026-04-15 and appears above the 1.10.3 entry.
- [ ] Spot-check that no named public bodies remain in LICENSE or CHANGELOG.
- [ ] Decide whether the README "License" section should add a one-line pointer to the clarification, or whether the existing "See LICENSE for full terms" is enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v1.10.4 Release Notes

* **Documentation**
  * Expanded non-commercial use clarification with examples of welcomed scenarios (personal use, public-sector support, non-profits).
  * Added commercial licensing guidance—users may contact via GitHub to obtain a commercial license with proceeds donated to charity support.
  * Added guidance for forks and derivatives regarding license retention and attribution.

* **Chores**
  * Incremented plugin version to 1.10.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->