### PR TITLE
Add cover letters, application tracker, referee prep, and Cowork scheduled routines (v1.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "career-helper",
-  "version": "1.11.0",
-  "description": "End-to-end career support for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Now includes personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library) alongside non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling",
+  "version": "1.12.0",
+  "description": "End-to-end career support for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Now includes cover letters and supporting statements, an application tracker, reference and referee prep, and ready-made Claude Cowork scheduled routines, alongside personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library) and non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling",
   "owner": {
     "name": "Prosper AI Consulting"
   },
@@ -9,7 +9,7 @@
     {
       "name": "career-helper",
       "source": "./career-helper",
-      "description": "End-to-end career support for job seekers at all levels. Employer footprint analysis, LinkedIn optimisation, ATS CV rewriting, interview preparation, company research, salary negotiation, personal brand building, and more."
+      "description": "End-to-end career support for job seekers at all levels. Employer footprint analysis, LinkedIn optimisation, ATS CV rewriting, cover letters, interview preparation, reference prep, company research, salary negotiation, an application tracker, personal brand building, and more."
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [1.12.0] - 2026-06-02
+
+### Added
+- **Cover Letter & Supporting Statement** capability in `/application-optimiser` (Capability 4). Drafts a full cover letter, a competency-based supporting statement (for public sector, charity, NHS, and academia), or a short application message, confirming the required format before drafting. Mirrors job-description language only where the underlying fact genuinely matches, sources motivation from the user rather than inventing it, and addresses overqualification, career change, and gaps where the CV cannot. Runs the existing anti-hallucination guardrails and reflective validation. New references `career-helper/skills/application-optimiser/references/cover-letter.md` and `cover-letter-template.md`. Outputs `applications/{role-slug}/cover-letter.md` or `supporting-statement.md`.
+- **Application Tracker** capability in `/career-navigator` (Capability 5). A single, plain-text board of every live application at `applications/tracker.md`, owned by the user and stored locally, as the private alternative to a paid tracking platform. Builds from a scan of existing application folders, then confirms each stage with the user; tracks role, organisation, stage, next action, and next date; uses fixed text-label stages (never colour coding); records only confirmed status; and surfaces one honest observation when the data warrants it (stalled pipeline, overdue actions, thin volume). New references `career-helper/skills/career-navigator/references/application-tracker.md` and `application-tracker-template.md`.
+- **Reference & Referee Prep** capability in `/interview-master` (Capability 5). Helps the user choose credible, relevant referees, ask permission well, brief each referee on what the role values and the verified examples they witnessed, and anticipate the questions referees face (including the more formal checks for regulated and safeguarding roles). Handles common constraints: a current employer who cannot be contacted yet, UK factual-only reference policies, a difficult last manager, and first jobs with no prior employer. Referee details come only from the user; briefs match verified shared history. New references `career-helper/skills/interview-master/references/referee-prep.md` and `referee-prep-template.md`. Outputs `applications/{role-slug}/referee-prep.md`.
+- **Scheduled Job-Search Routines (Claude Cowork)** capability in `/getting-started` (Capability 7). Ready-made `/schedule` prompts that turn the job search into a living process: a Monday job-search standup that reads the tracker, a weekly market and role monitor, a LinkedIn posting reminder aligned to the content calendar, a weekday follow-up check, and an on-demand pre-interview nudge. States the two honest limitations plainly: the computer must be awake with Claude Desktop open, and scheduling is a Cowork feature rather than part of the plugin (CLI and web users can run the same prompts manually). Each prompt retains a "do not invent" instruction. New reference `career-helper/skills/getting-started/references/scheduled-routines.md`.
+
+### Changed
+- Plugin and marketplace version bumped to 1.12.0
+- Plugin and marketplace descriptions updated to mention cover letters and supporting statements, the application tracker, reference and referee prep, and Cowork scheduled routines
+- `/career-helper:status` now checks for `applications/tracker.md` first and uses it as the spine of the progress summary, falling back to a folder scan when no tracker exists, flagging any tracker that looks out of date against the files on disk, and offering to build a tracker when application folders exist without one. Folder scan list extended with `cover-letter.md`, `supporting-statement.md`, and `referee-prep.md`
+- `/career-helper:help` and `/career-helper:quick-start` routing updated to recognise cover letter, supporting statement, application tracking, referee, and "automate my job search" phrasing
+- Getting Started reference guides (`full-overview.md`, `skill-tips.md`, `power-user-strategies.md`, `getting-the-best-guide.md`) updated to cover the four new capabilities
+- Tim routing (`career-helper/agents/tim.md`, `career-helper/skills/tim/SKILL.md`, and `career-helper/skills/tim/references/tim-skill-routing-guide.md`) updated so Tim can route to the new capabilities and scan for their outputs
+- README skills table, output file table, typical workflow, and features list updated; per-skill SKILL.md versions bumped (Application Optimiser 1.4.0, Career Navigator 1.4.0, Interview Master 1.5.0, Getting Started 1.12.0)
+
+### House style
+- All new content adheres to the house style codified in v1.10.1: no em dashes, UK English throughout, Oxford comma, hyphenated compound modifiers, no emojis or emoji-style markers, no hyperbole, second-person coaching voice. Existing files were not retrofitted.
+
+---
+
 ## [1.11.0] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Career Helper - Claude Code Plugin
 
-End-to-end career support with guided coaching for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Twelve skills including Tim (your personal career coach who guides you through the right skills in the right order), getting started guidance, AI impact assessment, employer footprint analysis, social media review, LinkedIn optimisation, ATS CV rewriting, interview preparation, job search strategy, career transitions (including non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling), board-level AI oversight, and personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library).
+End-to-end career support with guided coaching for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Twelve skills including Tim (your personal career coach who guides you through the right skills in the right order), getting started guidance, AI impact assessment, employer footprint analysis, social media review, LinkedIn optimisation, ATS CV rewriting, cover letters and supporting statements, interview preparation, reference and referee prep, job search strategy with an application tracker, career transitions (including non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling), board-level AI oversight, and personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library). Ready-made Claude Cowork scheduled routines keep the search moving between sessions.
 
 Available to all Claude users, including free subscriptions.
 
@@ -67,13 +67,13 @@ Or just describe what you need:
 
 | Skill | What It Does | Command |
 |:------|:-------------|:--------|
-| **Getting Started** | Full overview, preparation checklists, workflow planning, skill tips, power user strategies | `/getting-started` |
+| **Getting Started** | Full overview, preparation checklists, workflow planning, skill tips, power user strategies, scheduled Cowork routines | `/getting-started` |
 | **Employer Footprint** | Digital footprint audit through employer's eyes, social media scan, credit-report style dashboard, interview questions from online presence | `/employer-footprint` |
 | **Social Media Review** | Quick social media check through recruiter's eyes, privacy cleanup guide. Especially useful for graduates and early career. | `/social-media-review` |
-| **Application Optimiser** | Company and role research, ATS-optimised CV rewriting, application strategy | `/application-optimiser` |
+| **Application Optimiser** | Company and role research, ATS-optimised CV rewriting, cover letters and supporting statements, application strategy | `/application-optimiser` |
 | **LinkedIn Coach** | Profile audit, headline optimisation, content strategy, post review, video scripts | `/linkedin-coach` |
-| **Interview Master** | Interview prep, mock interviews, interviewer perspective reports, post-interview coaching, ageism support (UK law, practical strategies, emotional resilience) | `/interview-master` |
-| **Career Navigator** | Networking intelligence, 3-month job search plans, salary negotiation, offer evaluation | `/career-navigator` |
+| **Interview Master** | Interview prep, mock interviews, interviewer perspective reports, post-interview coaching, reference and referee prep, ageism support (UK law, practical strategies, emotional resilience) | `/interview-master` |
+| **Career Navigator** | Networking intelligence, 3-month job search plans, salary negotiation, offer evaluation, application tracker | `/career-navigator` |
 | **Career Transitions** | Portfolio and fractional careers, AI readiness assessment, non-linear career exploration (entrepreneurship, startups, public sector, charity, intrapreneurship, multi-role skilling) | `/career-transitions` |
 | **AI Impact Assessment** | Researches whether AI will materially disrupt your role in the next 12 months, with a 6-month mitigation plan | `/ai-impact-assessment` |
 | **NED AI Helper** | AI governance for Non-Executive Directors, Board Governors, and Charity Trustees. Challenge frameworks, risk assessment, governance structures, regulatory guidance | `/ned-ai-helper` |
@@ -98,15 +98,20 @@ Or just describe what you need:
 **Or run skills yourself:**
 
 ```
-0. Audit your digital footprint  /employer-footprint
-1. Research the company          /application-optimiser
-2. Optimise your CV              /application-optimiser
-3. Sync your LinkedIn            /linkedin-coach
-4. Prepare for interviews        /interview-master
-5. Practice with mock interview  /interview-master
-6. Negotiate your offer          /career-navigator
-7. Evaluate competing offers     /career-navigator
+0. Audit your digital footprint   /employer-footprint
+1. Research the company           /application-optimiser
+2. Optimise your CV               /application-optimiser
+3. Write your cover letter        /application-optimiser
+4. Sync your LinkedIn             /linkedin-coach
+5. Track every application        /career-navigator
+6. Prepare for interviews         /interview-master
+7. Practice with mock interview   /interview-master
+8. Prepare your references        /interview-master
+9. Negotiate your offer           /career-navigator
+10. Evaluate competing offers     /career-navigator
 ```
+
+**Tip:** Inside Claude Cowork, run `/getting-started` and ask about scheduled routines to set up a weekly job-search standup, market monitor, and follow-up check that keep the search moving.
 
 ---
 
@@ -117,6 +122,10 @@ Or just describe what you need:
 - **Region-aware** guidance for UK, US, EU, and APAC markets
 - **Research-driven** with cited sources and access dates
 - **ATS-optimised** CV output with keyword coverage analysis
+- **Cover letters and supporting statements** with the same anti-hallucination guardrails as CV work
+- **Application tracker** a single plain-text board of every live application, owned by you and read by `/career-helper:status`
+- **Reference and referee prep** choosing, asking, and briefing referees, with UK conventions and regulated-role notes
+- **Scheduled routines for Claude Cowork** ready-made `/schedule` prompts for a weekly standup, market monitor, and follow-up check
 - **Career stage adaptation** from graduates to late career
 - **Wellbeing-aware coaching** Tim reads emotional signals, acknowledges difficulty before routing, checks in after heavy work, and carries wellbeing context across sessions
 - **Ageism support** UK law, practical strategies, and emotional resilience for age-related rejection
@@ -136,6 +145,8 @@ Skills generate markdown files you can convert to other formats:
 |:-------|:-------------|
 | `{role}-research-brief.md` | Application Optimiser |
 | `{role}-cv-optimized.md` | Application Optimiser |
+| `{role}-cover-letter.md` | Application Optimiser |
+| `{role}-supporting-statement.md` | Application Optimiser |
 | `{role}-application-strategy.md` | Application Optimiser |
 | `{role}-linkedin-profile-review.md` | LinkedIn Coach |
 | `{role}-content-strategy.md` | LinkedIn Coach |
@@ -143,10 +154,12 @@ Skills generate markdown files you can convert to other formats:
 | `{role}-interview-prep.md` | Interview Master |
 | `{role}-interviewer-perspective.md` | Interview Master |
 | `{role}-post-interview-debrief.md` | Interview Master |
+| `{role}-referee-prep.md` | Interview Master |
 | `{role}-networking-intelligence.md` | Career Navigator |
 | `three-month-plan.md` | Career Navigator |
 | `{role}-negotiation-strategy.md` | Career Navigator |
 | `offer-evaluation.md` | Career Navigator |
+| `applications/tracker.md` | Career Navigator |
 | `portfolio-career-strategy.md` | Career Transitions |
 | `ai-readiness-plan.md` | Career Transitions |
 | `non-linear-career-exploration.md` | Career Transitions |
@@ -207,4 +220,4 @@ See [LICENSE](LICENSE) for full terms.
 
 ---
 
-*Career Helper Plugin v1.11.0 | Prosper AI Consulting, UK*
+*Career Helper Plugin v1.12.0 | Prosper AI Consulting, UK*

--- a/career-helper/.claude-plugin/plugin.json
+++ b/career-helper/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "career-helper",
-  "version": "1.11.0",
-  "description": "End-to-end career support with guided coaching for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Twelve skills including Tim (your personal career coach), getting started guidance, AI impact assessment, employer footprint analysis, social media review, LinkedIn optimisation, ATS CV rewriting, interview preparation, job search strategy, career transitions (including non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling), board-level AI oversight, and personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library).",
+  "version": "1.12.0",
+  "description": "End-to-end career support with guided coaching for job seekers at all levels, plus AI governance guidance for Non-Executive Directors and Board Governors. Twelve skills including Tim (your personal career coach), getting started guidance, AI impact assessment, employer footprint analysis, social media review, LinkedIn optimisation, ATS CV rewriting, cover letters and supporting statements, interview preparation, reference and referee prep, job search strategy with an application tracker, career transitions (including non-linear career exploration: entrepreneurship, startups, public sector, charity, intrapreneurship, and multi-role skilling), board-level AI oversight, and personal brand building (Why You, Why Them, Why Now positioning, audience and channel map, content pillars, bio library). Ready-made Claude Cowork scheduled routines keep the search moving.",
   "author": {
     "name": "Prosper AI Consulting"
   }

--- a/career-helper/agents/tim.md
+++ b/career-helper/agents/tim.md
@@ -115,10 +115,10 @@ Tim has access to 11 specialist skills. He can run any of them directly during a
 | 1 | Getting Started (`/getting-started`) | Plugin orientation, preparation checklists, workflow planning |
 | 2 | Employer Footprint (`/employer-footprint`) | Full digital footprint audit with 8-agent research swarm |
 | 3 | Social Media Review (`/social-media-review`) | Lightweight social media check through a recruiter's eyes |
-| 4 | Application Optimiser (`/application-optimiser`) | Company research, ATS-optimised CV, application strategy |
+| 4 | Application Optimiser (`/application-optimiser`) | Company research, ATS-optimised CV, cover letters and supporting statements, application strategy |
 | 5 | LinkedIn Coach (`/linkedin-coach`) | Profile audit, content strategy, headline optimisation |
-| 6 | Interview Master (`/interview-master`) | Preparation, mock interviews, post-rejection coaching, ageism support |
-| 7 | Career Navigator (`/career-navigator`) | Networking, job search planning, salary negotiation, offer evaluation |
+| 6 | Interview Master (`/interview-master`) | Preparation, mock interviews, post-rejection coaching, reference and referee prep, ageism support |
+| 7 | Career Navigator (`/career-navigator`) | Networking, job search planning, salary negotiation, offer evaluation, application tracker |
 | 8 | Career Transitions (`/career-transitions`) | Portfolio/fractional careers, AI readiness, non-linear career exploration |
 | 9 | AI Impact Assessment (`/ai-impact-assessment`) | Role disruption risk assessment with 6-month mitigation plan |
 | 10 | NED AI Helper (`/ned-ai-helper`) | Board-level AI governance for NEDs, governors, and trustees |

--- a/career-helper/commands/help.md
+++ b/career-helper/commands/help.md
@@ -11,11 +11,11 @@ You are a career support navigator. Help the user find the right skill for their
 
 | Skill | What It Does | Best For |
 |:------|:-------------|:---------|
-| **/getting-started** | Full overview with examples, preparation checklists, workflow planning, tips | New users, or getting the most out of career-helper |
+| **/getting-started** | Full overview with examples, preparation checklists, workflow planning, tips, scheduled Cowork routines | New users, getting the most out of career-helper, or automating the search |
 | **/linkedin-coach** | Profile audit, headlines, content strategy, post review, video scripts | Improving your LinkedIn presence |
-| **/application-optimiser** | Company research, ATS CV rewriting, application strategy | Applying for specific roles |
-| **/interview-master** | Interview prep, mock interviews, post-interview coaching, ageism support | Before and after interviews, age discrimination concerns |
-| **/career-navigator** | Networking, 3-month plans, salary negotiation, offer evaluation | Planning your job search strategy |
+| **/application-optimiser** | Company research, ATS CV rewriting, cover letters and supporting statements, application strategy | Applying for specific roles |
+| **/interview-master** | Interview prep, mock interviews, post-interview coaching, reference and referee prep, ageism support | Before and after interviews, preparing references, age discrimination concerns |
+| **/career-navigator** | Networking, 3-month plans, salary negotiation, offer evaluation, application tracker | Planning and tracking your job search strategy |
 | **/career-transitions** | Portfolio careers, fractional executive roles, AI readiness, non-linear career exploration (entrepreneurship, startups, public sector, charity, intrapreneurship, multi-role skilling) | Changing career direction or exploring alternatives to traditional employment |
 | **/employer-footprint** | Digital footprint audit through employer's eyes, social media scan, interview questions from online presence | Checking what employers will find about you online |
 | **/social-media-review** | Quick social media check through recruiter's eyes, privacy cleanup guide | Graduates, early career, or anyone wanting a quick social media health check |
@@ -32,9 +32,12 @@ If the user described their situation, route them:
 |:----------|:----------|
 | "I need to update my LinkedIn" | /linkedin-coach |
 | "I'm applying for a job" | /application-optimiser |
+| "Write a cover letter" or "help with my supporting statement" | /application-optimiser (cover letter) |
 | "I have an interview coming up" | /interview-master |
 | "I got rejected" | /interview-master (post-interview coaching) |
+| "They asked for references" or "who should I use as a referee?" | /interview-master (reference and referee prep) |
 | "I need a job search plan" | /career-navigator |
+| "Help me track my applications" or "where am I with all my applications?" | /career-navigator (application tracker) |
 | "I got an offer" | /career-navigator (salary negotiation or offer evaluation) |
 | "I want to go freelance/fractional" | /career-transitions |
 | "How do I show AI skills?" | /career-transitions (AI readiness) |
@@ -93,6 +96,7 @@ If the user described their situation, route them:
 | "Give me the getting the best guide" | /getting-started (getting the best guide) |
 | "How do I get the best results?" | /getting-started (getting the best guide) |
 | "Can I get a guide to share?" | /getting-started (getting the best guide) |
+| "Can I automate my job search?" or "set up a weekly routine" | /getting-started (scheduled routines, Cowork) |
 
 ## Response Format
 

--- a/career-helper/commands/quick-start.md
+++ b/career-helper/commands/quick-start.md
@@ -81,9 +81,12 @@ Based on their answers, recommend ONE skill and invoke it:
 | Situation | Skill to Invoke |
 |:----------|:----------------|
 | Has target role | /application-optimiser |
+| Needs a cover letter or supporting statement | /application-optimiser (cover letter) |
 | No target, needs plan | /career-navigator |
+| Wants to track or see all their applications | /career-navigator (application tracker) |
 | Interview coming | /interview-master |
 | Post-rejection | /interview-master |
+| Asked for references, choosing or briefing referees | /interview-master (reference and referee prep) |
 | Has offer | /career-navigator |
 | LinkedIn improvement | /linkedin-coach |
 | Digital footprint audit (general) | /employer-footprint |
@@ -121,6 +124,7 @@ Based on their answers, recommend ONE skill and invoke it:
 | Just exploring | /getting-started (full overview) |
 | "How does this work?" | /getting-started |
 | Wants a guide to read or share | /getting-started (getting the best guide) |
+| Wants to automate or schedule the search (Claude Cowork) | /getting-started (scheduled routines) |
 
 ## Handoff
 

--- a/career-helper/commands/status.md
+++ b/career-helper/commands/status.md
@@ -12,6 +12,14 @@ Check for `career-helper-preferences.md` in the current working directory. If fo
 
 ---
 
+## Check for the Tracker First
+
+Before scanning folders, check for `applications/tracker.md`. If it exists, read it and use it as the spine of the status summary: the active and closed tables already hold each application's stage, next action, and next date. Present that board first, then supplement with any output files found in the scan below. If the tracker looks out of date compared with the files on disk (for example, a folder has an `interview-prep.md` but the tracker still shows "Applied"), note the discrepancy and offer to refresh the tracker via `/career-navigator` (Application Tracker).
+
+If no tracker exists but application folders do, offer to build one: "Would you like me to create an application tracker so you can see every role and its next action in one place?" Route to `/career-navigator` (Application Tracker) if yes.
+
+---
+
 ## Check for Existing Outputs
 
 Look for career-helper output files in two locations:
@@ -24,11 +32,14 @@ Scan `applications/*/` for per-application subfolders. Each subfolder represents
 applications/{role-slug}/
 - research-brief.md
 - cv-optimised.md
+- cover-letter.md
+- supporting-statement.md
 - linkedin-updates.md
 - application-strategy.md
 - interview-prep.md
 - interviewer-perspective.md
 - post-interview-debrief.md
+- referee-prep.md
 - networking-intelligence.md
 - negotiation-strategy.md
 - linkedin-profile-review.md

--- a/career-helper/skills/application-optimiser/SKILL.md
+++ b/career-helper/skills/application-optimiser/SKILL.md
@@ -15,6 +15,7 @@ Research companies, optimise your CV for ATS systems, and plan your application 
 | 1 | Company Research | Before applying or interviewing at a target company |
 | 2 | CV/ATS Optimisation | Tailoring your CV for a specific role |
 | 3 | Application Strategy | Planning your full application approach |
+| 4 | Cover Letter | Writing a cover letter, supporting statement, or application message |
 
 ## Quick Start
 
@@ -22,6 +23,8 @@ Research companies, optimise your CV for ATS systems, and plan your application 
 "Research [Company] before I apply"
 "Help me optimise my CV for this job description"
 "Plan my application to [Company] for [Role]"
+"Write a cover letter for this role"
+"Help me with the supporting statement for this application"
 ```
 
 ---
@@ -90,9 +93,28 @@ Comprehensive planning:
 - Stakeholder mapping and connection strategy
 - Risk mitigation for identified gaps
 - Follow-up protocols and decision framework
-- Cover letter approach
+- Cover letter approach (for a full draft, use Capability 4)
 
 **Output:** `applications/{role-slug}/application-strategy.md`
+
+---
+
+## 4. Cover Letter & Supporting Statement
+
+**What you need:** Job description + your CV (or master facts) + research brief if one exists + your own reasons for wanting the role
+**Load:** @references/cover-letter.md
+**Template:** @references/cover-letter-template.md
+
+Drafts a cover letter, competency-based supporting statement, or short application message, with every claim traceable to verified content:
+- Confirms which format the application actually requires before drafting
+- Mirrors job-description language only where the underlying fact genuinely matches
+- Sources motivation from you, never inventing reasons you care about the organisation
+- Addresses overqualification, career change, or gaps honestly where the CV cannot
+- Runs the same anti-hallucination guardrails and reflective validation as CV work
+
+**Output:**
+- `applications/{role-slug}/cover-letter.md` (full letter)
+- `applications/{role-slug}/supporting-statement.md` (competency-based applications)
 
 ---
 
@@ -183,4 +205,4 @@ After optimising your application:
 
 ---
 
-*Application Optimiser v1.3.0 | Career Helper Plugin | Prosper AI Consulting, UK*
+*Application Optimiser v1.4.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/application-optimiser/references/cover-letter-template.md
+++ b/career-helper/skills/application-optimiser/references/cover-letter-template.md
@@ -1,0 +1,77 @@
+# Cover Letter: {{ROLE_TITLE}} at {{COMPANY_NAME}}
+
+**Generated:** {{DATE}}
+**Target Role:** {{ROLE_TITLE}}
+**Organisation:** {{COMPANY_NAME}}
+**Format:** {{Full letter / Supporting statement / Short message}}
+
+---
+
+## Draft
+
+{{FIRST_NAME}} {{LAST_NAME}}
+{{EMAIL}} | {{PHONE}} | {{LINKEDIN_URL}}
+{{CITY, COUNTRY}}
+
+{{DATE}}
+
+{{HIRING_MANAGER_NAME}}
+{{HIRING_MANAGER_TITLE}}
+{{COMPANY_NAME}}
+
+Dear {{HIRING_MANAGER_NAME / Hiring Team}},
+
+{{OPENING: the role you are applying for, and one specific, genuine reason you are drawn to this organisation. Sourced from the user or the research brief, never invented.}}
+
+{{EVIDENCE PARAGRAPH ONE: the single most relevant verified qualification, told as a brief example. Mirror job-description language only where the underlying fact genuinely matches.}}
+
+{{EVIDENCE PARAGRAPH TWO: a second relevant strength addressing a different requirement. Quantify only with numbers that appear in the source material.}}
+
+{{CLOSE: why this organisation specifically, tied to the user's own goals or values, and a short, confident call to action.}}
+
+Yours sincerely,
+{{FIRST_NAME}} {{LAST_NAME}}
+
+---
+
+## Source Trace (internal, not part of the letter)
+
+Record where each substantive claim came from. Remove this section before the user sends the letter.
+
+| Claim in letter | Source | Location |
+|:----------------|:-------|:---------|
+| {{Claim}} | {{CV / master facts / research brief / conversation}} | {{Section or turn}} |
+| {{Claim}} | {{Source}} | {{Location}} |
+
+**Flagged for clarification:**
+- {{Any point the user still needs to confirm before sending. If none, state "None."}}
+
+---
+
+## Supporting Statement Variant (use only for competency-based applications)
+
+Delete this section if a full letter or short message is being produced.
+
+### {{ESSENTIAL_CRITERION_1}}
+{{Verified STAR example: Situation, Task, Action, Result.}}
+
+### {{ESSENTIAL_CRITERION_2}}
+{{Verified STAR example.}}
+
+### {{ESSENTIAL_CRITERION_3}}
+{{Verified STAR example.}}
+
+### Desirable criteria
+{{Brief evidence against each desirable criterion.}}
+
+---
+
+## Short Message Variant (use only for email body or quick-apply boxes)
+
+Delete this section if a full letter or supporting statement is being produced.
+
+{{Three to four sentences: the role and one specific reason for interest, the strongest verified qualification, and a short, direct close.}}
+
+---
+
+*Generated using Career Helper. Found this helpful? Share your success story or suggest improvements at https://github.com/Zal4DW/career-helper*

--- a/career-helper/skills/application-optimiser/references/cover-letter.md
+++ b/career-helper/skills/application-optimiser/references/cover-letter.md
@@ -1,0 +1,137 @@
+# Cover Letter and Supporting Statement
+
+**Purpose:** Draft a cover letter, supporting statement, or short application message that is specific, honest, and traceable to verified content. A cover letter earns its place by saying what the CV cannot: why this role, why this organisation, and why now.
+
+**Applies to:** All cover letter, supporting statement, and application message output produced by application-optimiser.
+
+---
+
+## Before You Draft: Load the Guardrails
+
+A cover letter is more prone to invention than a CV, because it invites narrative. Load the guardrails first.
+
+**Load:** @references/verified-content-guardrails.md
+
+The Iron Rule applies in full: never invent, extrapolate, or infer details about work history, achievements, metrics, scope, or motivation. If you cannot cite the source, do not write it. A shorter, honest letter beats a longer, embellished one.
+
+Motivation is the one area unique to a cover letter. Do not invent reasons the user cares about the organisation. Ask them. "What specifically drew you to this role?" is a better question than guessing from the careers page.
+
+---
+
+## What You Need
+
+1. **The job description.** Source for what the role values and the language to mirror.
+2. **The user's current CV or master facts file.** Source for every claim about their experience.
+3. **A research brief if one exists** (`applications/{role-slug}/research-brief.md`). Source for what is true about the organisation. If none exists, offer to run Company Research first, or work from what the user can tell you.
+4. **The user's own words on motivation.** Ask why this role and this organisation matter to them. Do not supply the answer.
+
+If the research brief and CV both exist in the application folder, read them before asking the user anything.
+
+---
+
+## Choose the Right Format
+
+Ask which format the application requires. Do not assume a traditional letter; many applications want something else.
+
+| Format | When to Use | Length |
+|:-------|:------------|:-------|
+| Full cover letter | Traditional application, attached as a separate document | One page, roughly 250 to 400 words |
+| Supporting statement | Public sector, charity, NHS, academia, or any competency-based application | As specified by the application, often 500 to 1,000 words against listed criteria |
+| Short application message | Email body, LinkedIn Easy Apply, or "anything else to add" boxes | 120 to 200 words |
+
+The structures below differ. Confirm the format before drafting.
+
+---
+
+## Structure: Full Cover Letter
+
+Four short paragraphs. Every claim traces to the CV, master facts, or the user's stated motivation.
+
+1. **The opening.** State the role you are applying for and one specific, genuine reason you are drawn to this organisation. The reason must come from the user or the research brief, not from invention. Avoid generic flattery ("I have long admired your work"). Name something concrete.
+2. **Evidence paragraph one.** The single most relevant qualification, told as a brief, verified example. Mirror the language of the job description where the underlying fact genuinely matches. Do not stretch a fact to fit a keyword.
+3. **Evidence paragraph two.** A second relevant strength, ideally addressing a different requirement from the first. Quantify only with numbers that appear in the source.
+4. **The close.** Why this organisation specifically, tied to the user's own goals or values, and a short, confident call to action. No grovelling, no presumption.
+
+---
+
+## Structure: Supporting Statement
+
+Competency-based applications score each criterion. Structure the statement to make scoring easy.
+
+1. Address each essential criterion in the order the application lists them.
+2. Use a clear heading or lead sentence per criterion so the assessor can find the evidence.
+3. Answer each with a verified STAR example (Situation, Task, Action, Result). Pull these from the CV, master facts, or interview-prep stories if they already exist.
+4. Cover desirable criteria briefly after the essential ones.
+5. Do not pad. Assessors mark against the criteria, not against length or eloquence.
+
+---
+
+## Structure: Short Application Message
+
+Three to four sentences.
+
+1. The role and one specific reason for interest.
+2. The single strongest verified qualification.
+3. A short, direct close.
+
+---
+
+## Tone
+
+- **Match the organisation.** A charity, a bank, and a startup expect different registers. Use the research brief and the job description to calibrate. When in doubt, lean professional and warm rather than casual.
+- **Second person is for your coaching to the user, not the letter.** The letter itself is written in the user's first-person voice ("I led", "I am drawn to").
+- **No hyperbole.** Avoid "passionate", "world-class", "thrilled", and "perfect fit" unless the user genuinely uses that language and means it. Specific beats effusive.
+- **No em dashes.** Use commas, semicolons, colons, or full stops.
+- **UK English** unless the role explicitly targets a US audience.
+
+---
+
+## Overqualification and Career Change
+
+The cover letter is the right place to address a concern the CV raises but cannot explain.
+
+- **Overqualified or flight-risk framing.** If the user's experience sits above the role, name the genuine reason they want it (a deliberate step back, a sector move, a values-led choice) in their own words. Do not invent a reason. If the user has no honest answer, that is worth a frank conversation: see the Coaching Voice section in `/career-navigator`.
+- **Career change or gap.** Frame the transition honestly and briefly. State the transferable evidence; do not over-explain or apologise.
+
+---
+
+## What Belongs in the Cover Letter, Not the CV
+
+- Motivation and fit that a list of achievements cannot convey.
+- A short, honest explanation for a gap, a pivot, or a relocation.
+- Context for an achievement that needs a sentence the CV has no room for.
+- Anything the research brief flagged as worth addressing directly (see the "mention in a cover letter rather than the CV" note in ATS-Helper).
+
+Do not repeat the CV. The letter complements it.
+
+---
+
+## Reflective Validation Before Delivery
+
+After drafting, run the same self-review the CV work uses.
+
+**Load:** @references/reflect-validate.md
+
+Then answer:
+
+1. Can every substantive claim be traced to the CV, master facts, research brief, or a stated motivation?
+2. Is the motivation the user's own, or did you supply it?
+3. Have you mirrored job-description language only where the underlying fact genuinely matches?
+4. Is it the right length for the format?
+5. Are there any invented adjectives, metrics, or reasons? Remove or verify them.
+
+If any answer is unsafe, fix it before presenting.
+
+---
+
+## Output
+
+**File:** `applications/{role-slug}/cover-letter.md`
+
+If the application requires a supporting statement, save as `applications/{role-slug}/supporting-statement.md`. If a short message, present it in conversation and offer to save.
+
+**Load template:** @references/cover-letter-template.md
+
+---
+
+*Cover Letter and Supporting Statement v1.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/career-navigator/SKILL.md
+++ b/career-helper/skills/career-navigator/SKILL.md
@@ -16,6 +16,7 @@ Plan your search, build your network, and navigate offers.
 | 2 | 3-Month Job Search Plan | Structuring your entire job search |
 | 3 | Salary Negotiation | After receiving an offer |
 | 4 | Offer Evaluation | Comparing multiple offers or evaluating a single one |
+| 5 | Application Tracker | Keeping every live application and its next action in one place |
 
 ## Quick Start
 
@@ -24,6 +25,8 @@ Plan your search, build your network, and navigate offers.
 "Help me create a 3-month job search plan"
 "I got an offer - help me negotiate"
 "I have multiple offers - help me decide"
+"Help me track my applications"
+"Where am I with all my applications?"
 ```
 
 ---
@@ -158,9 +161,27 @@ Comprehensive offer analysis:
 
 ---
 
+## 5. Application Tracker
+
+**What you need:** Nothing to start; existing application folders if any
+**Load:** @references/application-tracker.md
+**Template:** @references/application-tracker-template.md
+
+A single, plain-text board of every live application, owned by the user and stored locally:
+- Builds from a scan of existing `applications/*/` folders, then confirms each stage with you
+- Tracks role, organisation, stage, next action, and next date per application
+- Uses fixed text-label stages (Researching through to Closed), never colour coding
+- Records only what you confirm or what existing files show, never inventing status
+- Surfaces one honest observation when the data warrants it (stalled pipeline, overdue actions, thin volume)
+- Read by `/career-helper:status` as the spine of your progress summary
+
+**Output:** `applications/tracker.md`
+
+---
+
 ## Application Folder
 
-Role-specific outputs (networking intelligence, negotiation strategy) are saved in `applications/{role-slug}/`. Cross-application outputs (three-month-plan, offer-evaluation) are saved in the workspace root. When running a role-specific capability, check if the application folder exists first using Glob. If it doesn't, create it when saving the first output.
+Role-specific outputs (networking intelligence, negotiation strategy) are saved in `applications/{role-slug}/`. Cross-application outputs (three-month-plan, offer-evaluation, tracker) are saved at the `applications/` level or workspace root. When running a role-specific capability, check if the application folder exists first using Glob. If it doesn't, create it when saving the first output.
 
 ---
 
@@ -225,4 +246,4 @@ When a capability specifies a template, you MUST:
 
 ---
 
-*Career Navigator v1.3.0 | Career Helper Plugin | Prosper AI Consulting, UK*
+*Career Navigator v1.4.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/career-navigator/references/application-tracker-template.md
+++ b/career-helper/skills/career-navigator/references/application-tracker-template.md
@@ -1,0 +1,38 @@
+# Application Tracker
+
+**Owner:** {{NAME}}
+**Last updated:** {{DATE}}
+
+A single view of every live application. Stages: Researching, Applying, Applied, Interviewing, Offer, Closed. Update the next action and date whenever something moves.
+
+---
+
+## Active Applications
+
+| Role | Organisation | Stage | Next action | Next date | Notes |
+|:-----|:-------------|:------|:------------|:----------|:------|
+| {{ROLE_TITLE}} | {{ORGANISATION}} | {{Researching/Applying/Applied/Interviewing/Offer}} | {{What you do next}} | {{YYYY-MM-DD or [UNKNOWN]}} | {{Short context}} |
+| {{ROLE_TITLE}} | {{ORGANISATION}} | {{Stage}} | {{Next action}} | {{Date}} | {{Note}} |
+| {{ROLE_TITLE}} | {{ORGANISATION}} | {{Stage}} | {{Next action}} | {{Date}} | {{Note}} |
+
+---
+
+## Closed
+
+| Role | Organisation | Outcome | Date closed | What you learned |
+|:-----|:-------------|:--------|:------------|:-----------------|
+| {{ROLE_TITLE}} | {{ORGANISATION}} | {{Accepted / Rejected / Withdrawn / No response}} | {{YYYY-MM-DD}} | {{One-line learning, if any}} |
+
+---
+
+## At a Glance
+
+- **Active applications:** {{count}}
+- **Awaiting response:** {{count}}
+- **Interviews booked:** {{count}}
+- **Offers in hand:** {{count}}
+- **Overdue actions:** {{list any next dates in the past, or "None"}}
+
+---
+
+*Generated using Career Helper. Found this helpful? Share your success story or suggest improvements at https://github.com/Zal4DW/career-helper*

--- a/career-helper/skills/career-navigator/references/application-tracker.md
+++ b/career-helper/skills/career-navigator/references/application-tracker.md
@@ -1,0 +1,93 @@
+# Application Tracker
+
+**Purpose:** Maintain a single, plain-text board of every live application so the user can see the whole search at a glance: what stage each role is at, what the next action is, and when it is due. This is the private, local alternative to a job-search spreadsheet or a paid tracking platform.
+
+**Applies to:** The tracker artefact at `applications/tracker.md`, created and updated by career-navigator and read by the `/career-helper:status` command.
+
+---
+
+## Principles
+
+1. **One file, one source of truth.** The tracker lives at `applications/tracker.md`. There is only ever one.
+2. **Plain text, fully portable.** A markdown table the user owns. No external service, no account, no data leaving their machine.
+3. **Never invent status.** Only record what the user has told you or what existing output files in the application folder confirm. If you do not know a stage or date, mark it `[UNKNOWN]` and ask.
+4. **Action-oriented.** Every active row must have a next action and, where known, a date. A tracker without next actions is just a list.
+5. **Honest about momentum.** If the user is stalled (many roles at "researching", none submitted), say so. See the Coaching Voice section in the main skill: overthinking versus applying.
+
+---
+
+## Building the Tracker from Scratch
+
+When no tracker exists, offer to create one.
+
+1. **Scan the application folders first.** Use Glob on `applications/*/` to find existing per-role work. Each subfolder is an application already in progress. Infer the likely stage from which files exist:
+   - `research-brief.md` only: stage is Researching.
+   - `cv-optimised.md` or `cover-letter.md` present: stage is Applying or Applied.
+   - `interview-prep.md` or `interviewer-perspective.md` present: stage is Interviewing.
+   - `post-interview-debrief.md` present: stage is Post-interview or Rejected (ask which).
+   - `negotiation-strategy.md` or `offer-evaluation.md` present: stage is Offer.
+2. **Confirm with the user.** Inferred stages are a starting point, not fact. Ask the user to correct anything and to add applications that have no folder yet.
+3. **Capture the essentials per row** (see the template): role, organisation, stage, next action, next date, and a short note.
+4. **Save** to `applications/tracker.md`.
+
+---
+
+## Stages
+
+Use this fixed, ordered set so the board reads consistently. These are text labels, never colour-coded, so they remain accessible.
+
+| Stage | Meaning |
+|:------|:--------|
+| Researching | Considering the role; research underway, not yet applied |
+| Applying | Tailoring CV, cover letter, or supporting statement |
+| Applied | Submitted, awaiting response |
+| Interviewing | One or more interview stages in progress |
+| Offer | Offer received; evaluating or negotiating |
+| Closed: accepted | Offer accepted |
+| Closed: rejected | Rejected, withdrawn, or no response after follow-up |
+
+---
+
+## Updating the Tracker
+
+When the user reports progress ("I submitted the Acme application", "I have a first interview Tuesday"), update the relevant row:
+
+1. Move the stage forward (or to a Closed state).
+2. Rewrite the next action and next date.
+3. Add a dated note if context matters (for example, "recruiter screen booked 12 June").
+4. Keep closed rows in a separate section at the bottom so the active board stays readable.
+
+Never silently overwrite history the user may want. If a role is rejected, move it to the closed section rather than deleting it; the pattern across closed roles is useful for `/interview-master` post-interview coaching.
+
+---
+
+## Reading the Board for Insight
+
+After updating, offer one honest observation when the data warrants it:
+
+- **Stalled pipeline:** several roles stuck at Researching or Applying, none Applied. "You have four roles in progress but none submitted yet. Which one is closest to ready?"
+- **Thin pipeline:** only one active application. Suggest building volume via `/application-optimiser`.
+- **Overdue actions:** next dates in the past. Surface them plainly.
+- **Healthy momentum:** acknowledge it briefly without flattery.
+
+Do not lecture. One useful observation beats a paragraph of coaching.
+
+---
+
+## Relationship to Other Outputs
+
+- The tracker is an index, not a replacement for the per-role files. Each row points to the work in `applications/{role-slug}/`.
+- The `/career-helper:status` command reads the tracker if it exists and uses it as the spine of the progress summary, falling back to a folder scan if there is no tracker.
+- The Application Strategy capability in `/application-optimiser` produces a per-role plan; the tracker aggregates across all roles.
+
+---
+
+## Output
+
+**File:** `applications/tracker.md`
+
+**Load template:** @references/application-tracker-template.md
+
+---
+
+*Application Tracker v1.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/getting-started/SKILL.md
+++ b/career-helper/skills/getting-started/SKILL.md
@@ -18,6 +18,7 @@ Get the most out of Career Helper. Whether you are a graduate writing your first
 | 4 | Skill-by-Skill Tips | Maximise results from any specific skill |
 | 5 | Power User Strategies | Advanced techniques for experienced users |
 | 6 | Getting the Best Guide | Comprehensive downloadable guide with scenario-based walkthroughs |
+| 7 | Scheduled Routines (Cowork) | Set up recurring job-search tasks in Claude Cowork |
 
 ## Quick Start
 
@@ -30,6 +31,8 @@ Get the most out of Career Helper. Whether you are a graduate writing your first
 "Show me advanced ways to use career-helper"
 "Can I get the getting the best guide?"
 "Give me the guide to share with someone"
+"Can I automate my job search?"
+"Set up a weekly routine for my job search"
 ```
 
 ---
@@ -153,6 +156,23 @@ Advanced techniques for users who have used the basic skills and want more.
 
 ---
 
+## 7. Scheduled Routines (Cowork)
+
+**What you need:** Claude Cowork on Claude Desktop, on a paid plan
+**Load:** @references/scheduled-routines.md
+
+Help the user turn their job search into a living process using Claude Cowork's scheduled tasks. Cowork can run a saved prompt on a schedule with full access to the Career Helper skills and the user's workspace folder.
+
+**Core approach:**
+- Explain how `/schedule` works and the two honest limitations: the computer must be awake with Claude Desktop open, and scheduling is a Cowork feature, not part of the plugin (CLI and web users can run the same prompts manually)
+- Offer the ready-made routines: Monday job-search standup, weekly market monitor, LinkedIn posting reminder, follow-up check, and pre-interview nudge
+- Recommend starting with one routine (usually the Monday standup) rather than all five
+- Keep the "do not invent" instruction in any prompt the user edits
+
+**Output:** Conversational setup guidance and copy-paste `/schedule` prompts
+
+---
+
 ## Response Approach
 
 When the user invokes this skill without specifying a capability:
@@ -163,6 +183,7 @@ When the user invokes this skill without specifying a capability:
    - "I need a plan for which skills to use and in what order" → Capability 3
    - "I want tips for getting better results from a specific skill" → Capability 4
    - "Give me the getting the best guide" → Capability 6
+   - "I want to automate or schedule parts of my job search" → Capability 7
 
 2. If the user is brand new or unsure, default to Capability 1 (Full Overview).
 
@@ -219,4 +240,4 @@ Or run **/career-helper:quick-start** if you want guided routing.
 
 ---
 
-*Getting Started Guide v1.11.0 | Career Helper Plugin | Prosper AI Consulting, UK*
+*Getting Started Guide v1.12.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/getting-started/references/full-overview.md
+++ b/career-helper/skills/getting-started/references/full-overview.md
@@ -32,9 +32,9 @@ Career-helper adapts to your stage. When presenting the overview, be aware of th
 
 ## The Eleven Skills - With Examples
 
-### Application Optimiser - Research, CV, and Strategy
+### Application Optimiser - Research, CV, Cover Letters, and Strategy
 
-**What it does:** Deep company research, ATS-optimised CV rewriting, and application strategy planning.
+**What it does:** Deep company research, ATS-optimised CV rewriting, cover letters and supporting statements, and application strategy planning.
 
 **Real example - applying for a specific role:**
 
@@ -62,6 +62,7 @@ Career-helper adapts to your stage. When presenting the overview, be aware of th
 - You have found a role you want to apply for
 - You want to understand a company before applying or interviewing
 - Your CV needs tailoring for a specific job description
+- You need a cover letter or a competency-based supporting statement that says what the CV cannot
 - You are a graduate and not sure how to make a thin CV stand out
 
 ---
@@ -114,7 +115,7 @@ Career-helper adapts to your stage. When presenting the overview, be aware of th
 
 ### Interview Master - Preparation, Practice, and Recovery
 
-**What it does:** Interview preparation with STAR frameworks, interviewer perspective reports, realistic mock interviews, and post-rejection coaching.
+**What it does:** Interview preparation with STAR frameworks, interviewer perspective reports, realistic mock interviews, post-rejection coaching, and reference and referee preparation.
 
 **Real example - preparing for an interview:**
 
@@ -156,13 +157,14 @@ Career-helper adapts to your stage. When presenting the overview, be aware of th
 - You want to understand what interviewers are really looking for
 - You want to practice with a mock interview
 - You have been rejected and want to improve
+- You have been asked for references and want to choose and brief your referees well
 - You have never done a formal interview before and want to feel prepared
 
 ---
 
 ### Career Navigator - Planning, Networking, and Offers
 
-**What it does:** Strategic networking intelligence, 3-month job search plans, salary negotiation coaching, and offer evaluation.
+**What it does:** Strategic networking intelligence, 3-month job search plans, salary negotiation coaching, offer evaluation, and an application tracker that keeps every live application and its next action in one place.
 
 **Real example - planning a job search:**
 
@@ -208,6 +210,7 @@ Career-helper adapts to your stage. When presenting the overview, be aware of th
 - You want to know who to connect with at a target company
 - You have received an offer and want to negotiate
 - You are comparing multiple offers
+- You want one place to track every application, its stage, and its next action
 - You have been made redundant and need structure and direction
 
 ---
@@ -419,6 +422,10 @@ In addition to skills, career-helper has three commands:
 | `/career-helper:help` | Shows all skills and routes you to the right one | You know you need help but are not sure which skill |
 | `/career-helper:quick-start` | Asks guided questions to find your starting point | You are brand new and want to be guided |
 | `/career-helper:status` | Shows all outputs you have generated and suggests next steps | You have used skills before and want to see progress |
+
+## Automating Your Search (Claude Cowork)
+
+If you use Career Helper inside Claude Cowork on Claude Desktop, you can put parts of the search on a schedule. Cowork's `/schedule` runs a saved prompt on a cadence (daily, weekly, weekdays, or on demand) with full access to the skills and your workspace folder. The getting-started skill offers ready-made routines: a Monday job-search standup that reads your tracker, a weekly market monitor, a LinkedIn posting reminder, a follow-up check, and a pre-interview nudge. Ask "can I automate my job search?" or run `/getting-started` and choose scheduled routines. Two honest caveats: your computer must be awake with Claude Desktop open, and scheduling is a Cowork feature (CLI and web users can run the same prompts manually).
 
 ## Getting the Best Guide
 

--- a/career-helper/skills/getting-started/references/getting-the-best-guide.md
+++ b/career-helper/skills/getting-started/references/getting-the-best-guide.md
@@ -27,10 +27,10 @@ Career Helper is not a single tool. It is a set of ten skills plus a guided coac
 | `/career-helper:career-coach` | **Tim — your career coach.** Understands your situation, runs the right skills in the right order, checks in between each one. Start here if you are unsure |
 | `/social-media-review` | Quick social media check through a recruiter's eyes |
 | `/employer-footprint` | Full digital footprint audit with a scored dashboard |
-| `/application-optimiser` | Company research, ATS CV optimisation, and application strategy |
+| `/application-optimiser` | Company research, ATS CV optimisation, cover letters and supporting statements, and application strategy |
 | `/linkedin-coach` | Profile audit, headline crafting, content strategy, and video intro scripts |
-| `/interview-master` | Interview prep, mock interviews, post-rejection coaching, and ageism support |
-| `/career-navigator` | Networking intelligence, 3-month plans, salary negotiation, and offer evaluation |
+| `/interview-master` | Interview prep, mock interviews, post-rejection coaching, reference and referee prep, and ageism support |
+| `/career-navigator` | Networking intelligence, 3-month plans, salary negotiation, offer evaluation, and an application tracker |
 | `/career-transitions` | Fractional/portfolio careers, AI readiness, and non-linear career exploration (entrepreneurship, startups, public sector, charity, intrapreneurship) |
 | `/ai-impact-assessment` | Honest assessment of AI disruption risk for your role, with a 6-month mitigation plan |
 | `/ned-ai-helper` | AI governance for Non-Executive Directors, Governors, and Trustees |
@@ -239,6 +239,8 @@ If you have been made redundant or have a career gap, the skill has a career ret
 
 Run the company research capability too. The intelligence brief covers leadership, financial health, hiring context, and red flags. When you are applying to roles at director level and above, knowing who the hiring manager reports to and what the board's strategic priorities are gives you a tangible edge.
 
+When a role needs a cover letter or a supporting statement, run `/application-optimiser` for that too. It drafts from your verified CV and the research brief, sources your motivation from you rather than inventing it, and is the right place to address an overqualification concern or a career gap that the CV cannot explain on its own.
+
 **Step 3: LinkedIn Overhaul**
 
 Run `/linkedin-coach` for the full profile audit. At your level, the content strategy capability is particularly valuable. Three posts a week, mixing tactical advice, strategic observations, and stories from your career, positions you as active and relevant. This directly counters any perception that you are "winding down" or out of touch.
@@ -275,6 +277,8 @@ Critically, it feeds those learnings back into your CV and interview prep. Each 
 
 - Run `/career-transitions` if you are considering going fractional or portfolio. It covers readiness assessment, rate setting, IR35 considerations, and client acquisition strategy.
 - Use `/career-navigator` to evaluate and negotiate offers. The salary negotiation coach is region-aware (UK, US, EU, APAC) and covers total compensation including pension, equity, notice periods, and garden leave.
+- When you are juggling several applications, run `/career-navigator` and build an application tracker. It is a single plain-text board of every role, its stage, and its next action, stored locally and read by `/career-helper:status`. It is the private alternative to a job-search spreadsheet.
+- When references are requested, run `/interview-master` for reference and referee prep. It helps you choose credible referees, ask them well, and brief each one on what the role values, with practical options when you cannot use your current employer yet.
 - Your research briefs, CV versions, and interview prep all save to per-application folders. When you are managing five active applications simultaneously, each one has its own folder with everything in one place. That is the difference between preparation and chaos.
 - If you would rather have someone manage the sequencing for you, run `/career-helper:career-coach`. Tim handles the routing and checks in between each skill — useful when you are juggling a lot and do not want to think about what to run next.
 
@@ -560,6 +564,7 @@ Career Helper skills are designed to feed into each other. Here is the chain:
 | Social media review or employer footprint | Identifies what to fix before applications |
 | Company research (application optimiser) | Informs CV tailoring, interview prep, and networking |
 | CV optimisation (application optimiser) | Produces a CV that LinkedIn coach and interview master reference |
+| Cover letter (application optimiser) | Says what the CV cannot: motivation, fit, and context for a gap or pivot |
 | LinkedIn coach (profile audit) | Creates consistency between CV and LinkedIn |
 | LinkedIn coach (content strategy) | Builds ongoing visibility and thought leadership |
 | Career navigator (networking intelligence) | Identifies who to connect with at target companies |
@@ -567,8 +572,10 @@ Career Helper skills are designed to feed into each other. Here is the chain:
 | Interview master (preparation) | Uses research brief and CV to build role-specific prep |
 | Interview master (mock interview) | Practises with realistic simulation |
 | Interview master (post-interview coaching) | Diagnoses rejection and feeds back into CV/prep refinement |
+| Interview master (reference and referee prep) | Helps you choose, ask, and brief referees at offer stage |
 | Career navigator (salary negotiation) | Coaches through offer negotiation with region-specific guidance |
 | Career navigator (offer evaluation) | Compares multiple offers with weighted decision framework |
+| Career navigator (application tracker) | Indexes every live application, its stage, and its next action |
 
 The persistent folder is what holds this chain together. Without it, each skill starts from scratch.
 
@@ -593,6 +600,7 @@ The persistent folder is what holds this chain together. Without it, each skill 
 To summarise, here is what you get across the full skill set:
 
 - **ATS-optimised CVs** tailored to specific job descriptions with 70%+ keyword coverage
+- **Cover letters and supporting statements** drafted from verified content, with the same anti-hallucination guardrails as the CV work
 - **Company intelligence briefs** covering leadership, culture, financials, red flags, and hiring context
 - **Digital footprint dashboards** scored across eight dimensions with text-label ratings
 - **LinkedIn profile audits** with headline optimisation, content strategy, and 4-week posting calendars
@@ -602,6 +610,9 @@ To summarise, here is what you get across the full skill set:
 - **Salary negotiation coaching** covering total compensation analysis across UK, US, EU, and APAC markets
 - **Offer evaluation frameworks** with weighted decision matrices for comparing multiple opportunities
 - **Post-rejection coaching** that diagnoses where things went wrong and feeds improvements back into your materials
+- **Reference and referee prep** to choose, ask, and brief your referees, with UK conventions and regulated-role notes
+- **An application tracker** that keeps every live application, its stage, and its next action in one plain-text board you own
+- **Scheduled routines for Claude Cowork** that put a Monday standup, market monitor, and follow-up check on repeat between sessions
 - **AI readiness assessments** with tiered upskilling roadmaps
 - **AI impact assessments** that research whether your role faces material disruption, with 6-month mitigation plans
 - **Fractional and portfolio career planning** including rate setting, IR35 guidance, and client acquisition strategy

--- a/career-helper/skills/getting-started/references/power-user-strategies.md
+++ b/career-helper/skills/getting-started/references/power-user-strategies.md
@@ -199,7 +199,8 @@ For users returning after a career break who want positioning that frames the ga
 **When to use:** You have generated multiple outputs over time and want to keep them current.
 
 **Approach:**
-- Run `/career-helper:status` periodically to see all generated files
+- Keep an application tracker (`/career-navigator`, Application Tracker) as the index of everything in flight; `/career-helper:status` reads it first
+- Run `/career-helper:status` periodically to see all generated files and the tracker board together
 - When your CV changes, re-run CV optimisation for active applications
 - When goals shift, re-run the 3-month plan
 - Research briefs older than 3 months should be refreshed - company situations change
@@ -211,6 +212,25 @@ For users returning after a career break who want positioning that frames the ga
 - Share with mentors or coaches for feedback
 - Use as reference during real interviews
 - Archive completed application folders when a role is finished
+
+---
+
+## Strategy 9: Automate the Search with Scheduled Tasks (Claude Cowork)
+
+**When to use:** You run Career Helper inside Claude Cowork on Claude Desktop and want the search to keep moving between sessions rather than only when you sit down to work on it.
+
+**Approach:**
+1. Keep an application tracker (`/career-navigator`) so a scheduled task has something to read
+2. Use Cowork's `/schedule` to set up recurring routines (see `/getting-started`, Scheduled Routines):
+   - **Monday standup** (weekly): reads the tracker, flags overdue actions, names the three things to do this week
+   - **Market monitor** (weekly): watches for new roles and news in your target area
+   - **Follow-up check** (weekdays): catches the follow-ups that slip
+   - **Posting reminder** (weekly): keeps your LinkedIn content cadence on track
+3. Start with one routine, usually the Monday standup, and add others once it is part of your week
+
+**Key insight:** the value compounds with a persistent workspace folder and a current tracker. Each scheduled run reads the same files, so the routines get more useful as your search progresses.
+
+**Two honest caveats:** scheduled tasks only run while your computer is awake with Claude Desktop open, and scheduling is a Cowork feature rather than part of the plugin. If you use the CLI or web app, run the same prompts manually.
 
 ---
 

--- a/career-helper/skills/getting-started/references/scheduled-routines.md
+++ b/career-helper/skills/getting-started/references/scheduled-routines.md
@@ -1,0 +1,103 @@
+# Scheduled Job-Search Routines
+
+**Purpose:** Turn the job search from a series of one-off sessions into a living process that keeps itself moving. Claude Cowork can run a saved prompt on a schedule (daily, weekly, weekdays only, or on demand), with full access to your skills, plugins, and local files each time. This guide gives you ready-made routines to drop into a scheduled task.
+
+**Applies to:** Users running Career Helper inside Claude Cowork on Claude Desktop, on a paid plan (Pro, Max, Team, or Enterprise).
+
+---
+
+## How Scheduled Tasks Work
+
+In Claude Cowork, type `/schedule` in the chat input to create a scheduled task. You write the prompt once, choose how often it runs, and Cowork runs it at that cadence as its own session. Each run can read your workspace folder and use the Career Helper skills, so a scheduled task can update your tracker, monitor the market, or remind you what to post.
+
+**Two honest limitations to know before you rely on this:**
+
+1. **Your computer must be awake and Claude Desktop must be open** for a scheduled task to run. If the machine is asleep or the app is closed at the scheduled time, Cowork skips that run and catches up the next time you open Claude Desktop.
+2. **Scheduled tasks are a Cowork feature, not part of the plugin itself.** The plugin supplies the skills; Cowork supplies the scheduler. If you are using Career Helper in the Claude Code CLI or the web app rather than Cowork on Desktop, these routines will not run on a timer. You can still run the same prompts manually whenever you like.
+
+Always keep your work in one folder (see the Workspace Tip in the README) so every scheduled run reads from and writes to the same place.
+
+---
+
+## Ready-Made Routines
+
+Copy a prompt below, run `/schedule`, paste it in, and set the cadence shown. Adjust the bracketed parts to your situation.
+
+### 1. Monday job-search standup (weekly, Monday morning)
+
+Reads your tracker and tells you what to do this week.
+
+```
+Read applications/tracker.md in my workspace. Give me a short Monday standup:
+1. Every active application and its next action, with anything overdue flagged first.
+2. Any application that has had no movement for over two weeks.
+3. The three most important things for me to do this week, in order.
+Keep it to one screen. Do not invent any application or status that is not in the tracker.
+```
+
+Cadence: Weekly, Monday.
+
+### 2. Weekly market and role monitor (weekly)
+
+Watches the market for your target roles so you are not searching from scratch each time.
+
+```
+Search for new job postings and relevant market news from the past seven days for
+[your target role, e.g. "Head of Marketing"] in [your location/region]. Use the
+career-navigator approach: cite sources with dates, and be honest about volume and
+seniority. List up to eight roles worth a closer look, with a one-line reason each.
+Save the summary to a dated file in my workspace. Do not pad the list to reach eight.
+```
+
+Cadence: Weekly.
+
+### 3. LinkedIn posting reminder (weekly, aligned to your content calendar)
+
+Keeps your personal-brand cadence on track without you having to remember it.
+
+```
+Read my content calendar (personal-brand-content-plan.md or content-calendar.md) if
+present in my workspace. Remind me what I planned to post this week and which content
+pillar it belongs to. Suggest one specific post idea drawn only from my existing pillars
+and notes. Do not invent achievements or claims about me.
+```
+
+Cadence: Weekly.
+
+### 4. Application follow-up check (weekdays)
+
+Catches the follow-ups that quietly slip.
+
+```
+Read applications/tracker.md and any application-strategy.md files in my workspace.
+Tell me which applications are due a follow-up today or are overdue, based on their
+next dates. For each, remind me of the follow-up step from the application strategy.
+If nothing is due, say so in one line. Do not invent dates or contacts.
+```
+
+Cadence: Weekdays.
+
+### 5. Pre-interview prep nudge (on demand)
+
+Set this up when an interview is booked, then trigger it the day before.
+
+```
+I have an interview for [role] at [company] on [date]. Read the interview-prep file in
+the matching applications folder. Give me a focused day-before checklist: the five
+stories to have ready, the questions I planned to ask, and the logistics to confirm.
+Keep it short and calm in tone.
+```
+
+Cadence: On demand.
+
+---
+
+## Adapting These
+
+- **Accessibility.** If you use dyslexia-friendly mode, the scheduled prompts will produce numbered, short-sentence output because every skill checks `career-helper-preferences.md` on each run. Keep that file in your workspace folder.
+- **Keep prompts honest.** Every routine above tells Claude not to invent applications, dates, or claims. Keep that instruction in if you edit a prompt; it is what stops a scheduled task from drifting into fabrication when a file is missing.
+- **Start with one.** The Monday standup is the highest-value routine for most people. Add others once it is part of your week.
+
+---
+
+*Scheduled Job-Search Routines v1.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/getting-started/references/skill-tips.md
+++ b/career-helper/skills/getting-started/references/skill-tips.md
@@ -44,10 +44,17 @@ After receiving your optimised CV:
 2. Ask: "Can you strengthen the [specific section] to better address [specific JD requirement]?"
 3. If you have additional experience not in your original CV, mention it - the skill will incorporate it
 
+### Cover Letters and Supporting Statements
+
+- **Tell the skill which format the application wants.** A full cover letter, a competency-based supporting statement (public sector, charity, NHS, academia), and a short email message are structured differently. Confirming this first saves a rewrite.
+- **Bring your own reason for wanting the role.** The skill will not invent your motivation. "Why does this organisation interest you?" is a question you need to answer; a specific, true reason is worth more than anything generated.
+- **Run company research first.** A cover letter that names something concrete about the organisation lands far better than generic flattery. The research brief gives the skill that material.
+- **Use it to address what the CV cannot:** an overqualification concern, a career change, or a gap. This is the right place for one honest sentence of context.
+
 ### What Feeds Into What
 
 ```
-Company Research → CV Optimisation → Application Strategy
+Company Research → CV Optimisation → Cover Letter → Application Strategy
        ↓                  ↓
 Interview Prep    LinkedIn Updates
 ```
@@ -108,6 +115,13 @@ CV Optimisation (sync LinkedIn with CV)
 4. Review feedback and update your preparation notes
 5. For a different stage at the same company, run Interview Preparation again with the new stage specified
 
+### Reference and Referee Prep
+
+- **Prepare before you are asked.** References are usually requested at offer stage, often with a tight turnaround. Choosing and briefing referees in advance avoids a scramble.
+- **Brief your referees.** The step most people skip. Give each referee the role, the two or three things it values, and a reminder of the specific examples they witnessed. A briefed referee gives a stronger reference than an impressive one caught cold.
+- **Be honest about constraints.** Cannot use your current employer yet? Have a difficult last manager? A UK factual-only reference policy? Say so; the skill has practical options for each.
+- **Match briefs to real history.** The skill will not coach a referee to claim something that did not happen. Pick referees who genuinely saw the work this role values.
+
 ### What Feeds Into What
 
 ```
@@ -116,6 +130,8 @@ Company Research → Interview Preparation → Mock Interview
               Interviewer's Perspective
                           ↓
               Post-Interview Coaching (after the real interview)
+                          ↓
+              Reference and Referee Prep (late interview or offer stage)
 ```
 
 ---
@@ -141,12 +157,18 @@ Company Research → Interview Preparation → Mock Interview
 - Networking: Run for each new target company.
 - Negotiation: Iterate as counter-offers come in - share new data and ask for updated strategy.
 
+### Application Tracker
+
+- **Let it build from your folders.** If you already have application folders, the tracker scans them and infers each stage, then asks you to confirm. You do not start from a blank table.
+- **Keep one tracker.** It lives at `applications/tracker.md`. Update the stage and next action whenever something moves; `/career-helper:status` reads it as the spine of your progress view.
+- **Use it to spot stalls.** If several roles sit at "researching" with none submitted, the tracker will say so. That honesty is the point; a tidy list with no next actions is not a tracker.
+
 ### What Feeds Into What
 
 ```
-3-Month Plan → Networking Intelligence → Application Phase
-                                              ↓
-                    Salary Negotiation ← Offer Received
+3-Month Plan → Networking Intelligence → Application Phase → Application Tracker
+                                              ↓                      ↑
+                    Salary Negotiation ← Offer Received    (every application logged here)
                            ↓
                     Offer Evaluation (if multiple offers)
 ```

--- a/career-helper/skills/interview-master/SKILL.md
+++ b/career-helper/skills/interview-master/SKILL.md
@@ -16,6 +16,7 @@ Complete interview support - before, during practice, and after.
 | 2 | Interviewer's Perspective | Understanding what interviewers really assess |
 | 3 | Mock Interview | Practising with realistic simulation |
 | 4 | Post-Interview Coaching | After a rejection or unsuccessful interview |
+| 5 | Reference & Referee Prep | Choosing, asking, and briefing your referees |
 
 ## Quick Start
 
@@ -27,6 +28,7 @@ Complete interview support - before, during practice, and after.
 "I think I was rejected because of my age"
 "I keep getting told I'm overqualified - what can I do?"
 "I was made redundant after 25 years and I'm struggling"
+"They asked for references - who should I use and how do I brief them?"
 ```
 
 ---
@@ -144,6 +146,29 @@ Realistic interview practice:
 
 ---
 
+## 5. Reference & Referee Prep
+
+**What you need:** The role and what it values + who you are considering as referees + any constraints (current employer, difficult last manager, first job)
+**Load:** @references/referee-prep.md
+**Template:** @references/referee-prep-template.md
+
+Prepare your references before you are asked, usually at late interview or offer stage:
+- Choose referees who are credible and relevant to this specific role
+- Ask permission well, in a way that lets a lukewarm referee decline gracefully
+- Brief each referee on what this role values and the verified examples they witnessed
+- Handle common constraints: a current employer who cannot be contacted yet, a UK factual-only reference policy, a difficult last manager, or a first job with no prior employer
+- Anticipate the questions referees are typically asked, including the more formal checks for regulated and safeguarding roles
+
+All referee details come from you; nothing is invented. Briefs match verified shared history, never coaching exaggeration.
+
+**Output:** `applications/{role-slug}/referee-prep.md`
+
+**Suggested next steps:**
+- "Want me to draft the brief to send each referee?"
+- "Ready for the offer and negotiation stage?" (route to `/career-navigator`)
+
+---
+
 ## Application Folder
 
 All role-specific outputs are saved in `applications/{role-slug}/`. When running any capability for a role, check if the folder exists first using Glob. If it doesn't, create it when saving the first output. If a research brief or CV already exists in the folder from a previous skill run, use those to inform interview preparation.
@@ -219,4 +244,4 @@ When a capability specifies a template, you MUST:
 
 ---
 
-*Interview Master v1.4.0 | Career Helper Plugin | Prosper AI Consulting, UK*
+*Interview Master v1.5.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/interview-master/references/referee-prep-template.md
+++ b/career-helper/skills/interview-master/references/referee-prep-template.md
@@ -1,0 +1,90 @@
+# Reference and Referee Preparation: {{ROLE_TITLE}} at {{ORGANISATION}}
+
+**Generated:** {{DATE}}
+**Target Role:** {{ROLE_TITLE}}
+**Organisation:** {{ORGANISATION}}
+**References requested:** {{Number, and type if specified}}
+
+---
+
+## What This Role Values
+
+The strengths your references should speak to, drawn from the job description:
+
+1. {{STRENGTH_1}}
+2. {{STRENGTH_2}}
+3. {{STRENGTH_3}}
+
+---
+
+## Your Referees
+
+| Referee | Relationship | Speaks best to | Permission asked? | Contact confirmed? |
+|:--------|:-------------|:---------------|:------------------|:-------------------|
+| {{NAME}} | {{Manager / Colleague / Client / Academic / Character}} | {{Which of the strengths above}} | {{Yes / Not yet}} | {{Yes / [TO CONFIRM]}} |
+| {{NAME}} | {{Relationship}} | {{Strength}} | {{Yes / Not yet}} | {{Yes / [TO CONFIRM]}} |
+
+**Constraints noted:**
+- {{e.g., current employer not to be contacted until offer agreed, or "None"}}
+
+---
+
+## Briefs to Send
+
+### Brief for {{REFEREE_1_NAME}}
+
+- **Role and organisation:** {{One or two lines}}
+- **What this role values:** {{The one or two strengths this referee should emphasise}}
+- **Examples to remind them of:** {{Specific, verified shared experiences. Do not invent.}}
+- **Anything to frame consistently:** {{Gap, pivot, or step the user is addressing, or "None"}}
+
+### Brief for {{REFEREE_2_NAME}}
+
+- **Role and organisation:** {{One or two lines}}
+- **What this role values:** {{Strengths}}
+- **Examples to remind them of:** {{Verified shared experiences}}
+- **Anything to frame consistently:** {{Note, or "None"}}
+
+---
+
+## Request Message (adapt per referee)
+
+```
+Hi {{NAME}},
+
+I am applying for {{ROLE_TITLE}} at {{ORGANISATION}} and would value you as a referee.
+It is a {{one-line description of the role and what it focuses on}}.
+
+Would you feel able to speak to my {{relevant strengths}}? If so, I will send a short
+brief so you have the context. References would likely be requested around {{timeframe}}.
+
+Thank you either way.
+{{USER_NAME}}
+```
+
+---
+
+## Likely Questions Your Referees Will Face
+
+- Dates of employment, job title, and reason for leaving
+- Main responsibilities and performance
+- Strengths and areas for development
+- Working with others and handling pressure
+- Reliability and conduct
+- "Would you re-employ?" or "Any reason we should not?"
+
+{{If this is a regulated or safeguarding role, note the more formal conduct and suitability checks here.}}
+
+---
+
+## Checklist
+
+- [ ] Referees chosen and relevant to this role
+- [ ] Permission asked and granted for each
+- [ ] Contact details confirmed
+- [ ] Brief sent to each referee
+- [ ] Current-employer constraint handled (if any)
+
+---
+
+*Generated using Career Helper. Found this helpful? Share your success story or suggest improvements at https://github.com/Zal4DW/career-helper*

--- a/career-helper/skills/interview-master/references/referee-prep.md
+++ b/career-helper/skills/interview-master/references/referee-prep.md
@@ -1,0 +1,126 @@
+# Reference and Referee Preparation
+
+**Purpose:** Help the user choose the right referees, ask them well, brief them so they can speak to the things this role actually values, and anticipate what they will be asked. A strong referee who is briefed beats an impressive one who is caught cold.
+
+**Applies to:** Reference and referee preparation produced by interview-master, typically at the late interview or offer stage.
+
+---
+
+## When This Matters
+
+References are usually requested at or just before offer stage, sometimes after a final interview. Prepare before you are asked, not in the rush afterwards. In the UK, listing "References available on request" is normal; you rarely volunteer names on the CV itself.
+
+Do not invent referee names, titles, or relationships. Every detail in the output must come from the user. Where a detail is missing, mark it `[TO CONFIRM]` and ask.
+
+---
+
+## What You Need
+
+1. The role and what it values (job description, or the research brief if one exists in the application folder).
+2. Who the user is considering as referees, and the user's relationship to each.
+3. Any constraints: a current employer who must not be contacted yet, a difficult last manager, a long gap, or a first job with no prior employer.
+
+---
+
+## Choosing Referees
+
+Help the user pick referees who are both credible and relevant to this role.
+
+- **Recency and relevance.** A recent line manager who saw the work that matters most for this role is worth more than a senior name who barely knew the user.
+- **Mix by type where allowed:**
+  - **Professional or employment reference:** a manager or senior colleague. The strongest default.
+  - **Character or personal reference:** for first jobs, career returners, or where requested.
+  - **Academic reference:** for graduates and early-career applicants.
+  - **Client or stakeholder reference:** useful for fractional, consulting, and portfolio work.
+- **Number.** Two is the usual ask; some employers want three. Confirm what the application specifies.
+- **Avoid common traps:** a referee who left the organisation years ago and is hard to reach, anyone who might be lukewarm, or a single referee asked to cover every angle.
+
+### Constraint: cannot use the current employer
+
+Common and legitimate. Options to discuss honestly:
+- A previous employer or a former manager who has since left the current organisation.
+- A senior colleague, client, or stakeholder who can speak to recent work discreetly.
+- Asking the prospective employer to delay contacting the current employer until an offer is agreed. This is a normal request.
+
+### Constraint: difficult last manager or a UK factual-only reference
+
+Many UK employers now give only a factual reference (dates of employment and job title) as policy. Reassure the user this is widespread and not a red flag. If the last manager relationship was poor, focus the substantive references elsewhere and let the factual reference stand for the dates.
+
+---
+
+## Asking a Referee
+
+Coach the user to ask properly, in advance.
+
+1. **Ask permission first, every time.** Never list someone as a referee without their agreement. This is both courtesy and, under UK data protection norms, the right thing to do.
+2. **Ask in a way that lets them decline gracefully.** "Would you feel able to give me a strong reference for this kind of role?" gives an honest out. A hesitant referee is information.
+3. **Give them what they need:** the role, the organisation, the timeline, and the brief below.
+4. **Confirm their preferred contact details** and the format they expect (a call, a form, a written reference).
+
+A short request template the user can adapt:
+
+```
+Hi [Name],
+
+I am applying for [role] at [organisation] and would value you as a referee.
+It is a [one-line description of the role and what it focuses on].
+
+Would you feel able to speak to my [the specific strengths relevant here]?
+If so, I will send a short brief so you have the context. References would
+likely be requested around [timeframe].
+
+Thank you either way.
+[User]
+```
+
+---
+
+## Briefing a Referee
+
+This is the step most people skip and the one that lifts a reference from adequate to strong.
+
+Give each referee a short brief covering:
+- The role and the organisation, in one or two lines.
+- The two or three things this role most values (drawn from the job description, never invented).
+- One or two specific examples they witnessed that show those strengths. Remind them of the detail; people forget.
+- Anything the user is proactively addressing (a gap, a pivot, a step down) so the referee is not surprised and frames it consistently.
+
+Match the briefing to verified history. If the user wants a referee to speak to a strength, there must be a real shared experience behind it. Do not coach a referee to claim something that did not happen.
+
+---
+
+## What Referees Are Typically Asked
+
+Prepare the user (and, through them, the referee) for the common questions:
+- Confirmation of dates of employment, job title, and reason for leaving.
+- The user's main responsibilities and how they performed.
+- Strengths and areas for development.
+- How they worked with others and handled pressure.
+- Timekeeping, reliability, and conduct.
+- "Would you re-employ this person?" or "Is there any reason we should not?"
+
+For roles in regulated or safeguarding settings (finance, healthcare, education, working with children or vulnerable adults), references are often more formal and may probe conduct and suitability directly. Note this where relevant.
+
+---
+
+## Consent, Accuracy, and Fairness
+
+- References must be truthful. A reference that is misleading can expose the referee and the user to risk. Never coach exaggeration.
+- The user can usually request to see a reference written about them. Mention this if they are anxious about what a referee might say.
+- Keep referees' personal contact details private and shared only with the prospective employer, with the referee's agreement.
+
+---
+
+## Output
+
+**File:** `applications/{role-slug}/referee-prep.md`
+
+**Load template:** @references/referee-prep-template.md
+
+**Suggested next steps:**
+- "Want me to draft the brief to send each referee?"
+- "Shall we prepare for the offer and negotiation stage?" (route to `/career-navigator`)
+
+---
+
+*Reference and Referee Preparation v1.0 | Career Helper Plugin | Prosper AI Consulting, UK*

--- a/career-helper/skills/tim/SKILL.md
+++ b/career-helper/skills/tim/SKILL.md
@@ -78,10 +78,10 @@ Tim has access to 11 specialist skills:
 | 1 | Getting Started (`/getting-started`) | Plugin orientation, preparation checklists, workflow planning |
 | 2 | Employer Footprint (`/employer-footprint`) | Full digital footprint audit with 8-agent research swarm |
 | 3 | Social Media Review (`/social-media-review`) | Lightweight social media check through a recruiter's eyes |
-| 4 | Application Optimiser (`/application-optimiser`) | Company research, ATS-optimised CV, application strategy |
+| 4 | Application Optimiser (`/application-optimiser`) | Company research, ATS-optimised CV, cover letters and supporting statements, application strategy |
 | 5 | LinkedIn Coach (`/linkedin-coach`) | Profile audit, content strategy, headline optimisation |
-| 6 | Interview Master (`/interview-master`) | Preparation, mock interviews, post-rejection coaching, ageism support |
-| 7 | Career Navigator (`/career-navigator`) | Networking, job search planning, salary negotiation, offer evaluation |
+| 6 | Interview Master (`/interview-master`) | Preparation, mock interviews, post-rejection coaching, reference and referee prep, ageism support |
+| 7 | Career Navigator (`/career-navigator`) | Networking, job search planning, salary negotiation, offer evaluation, application tracker |
 | 8 | Career Transitions (`/career-transitions`) | Portfolio/fractional careers, AI readiness, non-linear career exploration |
 | 9 | AI Impact Assessment (`/ai-impact-assessment`) | Role disruption risk assessment with 6-month mitigation plan |
 | 10 | NED AI Helper (`/ned-ai-helper`) | Board-level AI governance for NEDs, governors, and trustees |

--- a/career-helper/skills/tim/references/tim-skill-routing-guide.md
+++ b/career-helper/skills/tim/references/tim-skill-routing-guide.md
@@ -8,7 +8,10 @@ This file is loaded by the Tim career coach skill when making routing decisions.
 
 Skills produce outputs that feed into other skills. Tim checks for existing outputs before deciding what to run next.
 
-- application-optimiser research brief feeds into: interview-master (company knowledge for prep), linkedin-coach (CV/LinkedIn consistency)
+- application-optimiser research brief feeds into: interview-master (company knowledge for prep), linkedin-coach (CV/LinkedIn consistency), application-optimiser cover letter (what the organisation is true about)
+- application-optimiser cover letter and supporting statement draw on: the research brief, the optimised CV or master facts, and the user's stated motivation; never invent motivation
+- interview-master referee prep draws on: the optimised CV and interview-prep STAR stories (verified examples the referee witnessed); runs at late interview or offer stage
+- career-navigator application tracker indexes: every per-application folder; it is the spine `/career-helper:status` reads, so update it when an application moves stage
 - employer-footprint results feed into: linkedin-coach (fix issues found), interview-master (questions from online presence)
 - social-media-review results feed into: linkedin-coach (cleanup recommendations), employer-footprint (if deeper audit needed)
 - career-transitions outputs feed into: application-optimiser (reposition CV for sector pivot), linkedin-coach (rebrand for fractional/portfolio), career-navigator (3-month plan for new path)
@@ -48,6 +51,8 @@ Tim uses Glob to scan for existing outputs before routing. Role-specific files a
 **Application Optimiser:**
 - `applications/{role-slug}/research-brief.md`
 - `applications/{role-slug}/cv-optimised.md`
+- `applications/{role-slug}/cover-letter.md`
+- `applications/{role-slug}/supporting-statement.md`
 - `applications/{role-slug}/linkedin-updates.md`
 - `applications/{role-slug}/application-strategy.md`
 
@@ -61,6 +66,7 @@ Tim uses Glob to scan for existing outputs before routing. Role-specific files a
 - `applications/{role-slug}/interview-prep.md`
 - `applications/{role-slug}/interviewer-perspective.md`
 - `applications/{role-slug}/post-interview-debrief.md`
+- `applications/{role-slug}/referee-prep.md`
 
 **Career Navigator (role-specific):**
 - `applications/{role-slug}/networking-intelligence.md`
@@ -74,6 +80,7 @@ Tim uses Glob to scan for existing outputs before routing. Role-specific files a
 **Career Navigator (shared):**
 - `three-month-plan.md`
 - `offer-evaluation.md`
+- `applications/tracker.md` (index of every live application; read by `/career-helper:status`)
 
 **Career Transitions:**
 - `portfolio-career-strategy.md`


### PR DESCRIPTION
## Summary

A review of [Claude Cowork's 2026 releases](https://claude.com/product/cowork) and the current AI career-tool landscape surfaced four gaps in the plugin. This PR closes them, all built into the existing skill, reference, template, and persona architecture (additive, so a minor bump to **v1.12.0**).

### What was missing, and why it matters

- **Cover letters**: every competitor (Careerflow, Teal, ApplyArc, Rezi) ships this; the plugin only mentioned "cover letter approach" in passing. The single biggest gap.
- **Application tracker**: rivals sell Kanban-style boards; `/status` scanned folders but produced no durable artefact.
- **Reference/referee prep**: not covered anywhere, despite being a real offer-stage need.
- **Scheduled routines**: Cowork now supports `/schedule` recurring tasks with full skill access; nothing in the plugin exploited it.

We deliberately **did not** build auto-apply or a live interview copilot, as both conflict with the plugin's verified-content, wellbeing-led ethos.

## New capabilities

| Skill | Capability | Output |
|:--|:--|:--|
| `/application-optimiser` | Cover Letter & Supporting Statement (4) | `applications/{role-slug}/cover-letter.md` or `supporting-statement.md` |
| `/career-navigator` | Application Tracker (5) | `applications/tracker.md` |
| `/interview-master` | Reference & Referee Prep (5) | `applications/{role-slug}/referee-prep.md` |
| `/getting-started` | Scheduled Routines, Cowork (7) | copy-paste `/schedule` prompts |

Each reuses existing patterns: the cover letter runs the same anti-hallucination guardrails and reflective validation as CV work and sources motivation from the user; the tracker uses fixed text-label stages (accessible, never colour); referee briefs match verified history only; the scheduled prompts retain a "do not invent" instruction and state Cowork's two honest limitations.

## New files (7)

- `application-optimiser/references/cover-letter.md` + `cover-letter-template.md`
- `career-navigator/references/application-tracker.md` + `application-tracker-template.md`
- `interview-master/references/referee-prep.md` + `referee-prep-template.md`
- `getting-started/references/scheduled-routines.md`

## Docs and guides updated

`/career-helper:help` and `/quick-start` routing, `/status` (now reads the tracker first and flags drift), README (skills table, output files, workflow, features), CHANGELOG, and the getting-started guides (`full-overview`, `skill-tips`, `power-user-strategies`, `getting-the-best-guide`). Tim's routing guide, output-file patterns, and skill tables in both `agents/tim.md` and `skills/tim/SKILL.md` updated so Tim can route to and scan for the new outputs.

Version bumped in `plugin.json` and `marketplace.json`; per-skill footers bumped (Application Optimiser 1.4.0, Career Navigator 1.4.0, Interview Master 1.5.0, Getting Started 1.12.0).

## House style

All new content follows the house rules: no em dashes, UK English, Oxford comma, no emojis, no hyperbole, second-person coaching voice. Verified clean.

## Note on the shareable PDF

`getting-the-best-guide.md` (the markdown source) is updated, but its companion `getting-the-best-guide.pdf` is a checked-in binary I cannot regenerate here. It is now slightly behind the markdown. Worth regenerating before release.

https://claude.ai/code/session_01KRq17Ahc93yoHsVDGh3Ryp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRq17Ahc93yoHsVDGh3Ryp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Career Helper v1.12.0

* **New Features**
  * Cover letter and supporting statement drafting capability added to Application Optimiser
  * Application tracker board to monitor all live applications added to Career Navigator
  * Reference and referee preparation guidance added to Interview Master
  * Scheduled job-search routines via Claude Cowork automation added to Getting Started

* **Documentation**
  * Updated skill guides, templates, and workflow references to reflect new capabilities
  * Added comprehensive guides for cover-letter generation, application tracking, and referee preparation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->